### PR TITLE
docs: Course section on user feedback collection

### DIFF
--- a/docs/08-secrets-and-production.md
+++ b/docs/08-secrets-and-production.md
@@ -470,12 +470,13 @@ helm upgrade my-agent chart/ \
 
 #### REST endpoints
 
-The server exposes three feedback endpoints:
+The server exposes four feedback endpoints:
 
 | Path | Method | Purpose |
 |------|--------|---------|
 | `/v1/feedback` | POST | Submit a rating (1 = thumbs-up, -1 = thumbs-down) |
 | `/v1/feedback` | GET | Query records, filterable by `trace_id`, `session_id`, time window |
+| `/v1/feedback/{feedback_id}` | PATCH | Edit an existing record in place — change the rating, revise the comment |
 | `/v1/feedback/stats` | GET | Aggregated counts grouped by time window (`hour` / `day` / `week`) |
 
 A minimal POST looks like this:
@@ -490,6 +491,20 @@ curl -X POST http://my-agent:8080/v1/feedback \
 identifier so feedback works even when tracing is disabled or sampled
 out. Records keyed to a real trace can be joined to the trace store;
 orphan records are still useful as raw rating data.
+
+When a user changes their mind on an already-rated message, send a PATCH
+with the new fields rather than posting again -- the record updates in
+place, no duplicate row is created. PATCH bodies are partial: omitted
+fields stay as they were.
+
+```bash
+# Capture the feedback_id from the original POST response, then:
+curl -X PATCH http://my-agent:8080/v1/feedback/fb_abc123 \
+  -H 'Content-Type: application/json' \
+  -d '{"rating":-1,"comment":"on second look, this was wrong"}'
+```
+
+Returns 200 with the full updated record, or 404 if the id is unknown.
 
 #### Where the trace_id comes from
 

--- a/docs/08-secrets-and-production.md
+++ b/docs/08-secrets-and-production.md
@@ -434,6 +434,124 @@ header) -- extracting it from incoming requests and injecting it into
 outgoing RemoteNode calls. This links spans across multi-agent workflows
 into a single distributed trace without any application-level code.
 
+### User feedback collection
+
+Metrics tell you the agent is fast. Traces tell you what it did. Neither
+tells you whether users were happy with the answer. Feedback collection
+closes that gap by storing thumbs-up / thumbs-down ratings, optional
+comments, and corrections -- joined to the trace that produced each
+response so you can replay the conversation behind a bad rating.
+
+This data is the raw material for two downstream pipelines: dashboards
+that surface degradations early, and labelled datasets for fine-tuning
+or RLHF.
+
+Enable feedback alongside tracing:
+
+```yaml
+server:
+  storage:
+    backend: sqlite             # or: postgres
+  traces:
+    enabled: true               # so feedback can join to a trace
+  feedback:
+    enabled: true
+    max_age_hours: 720          # keep 30 days
+```
+
+Override via Helm or env vars:
+
+```bash
+helm upgrade my-agent chart/ \
+  --set config.STORAGE_BACKEND=sqlite \
+  --set config.TRACES_ENABLED=true \
+  --set config.FEEDBACK_ENABLED=true
+```
+
+#### REST endpoints
+
+The server exposes three feedback endpoints:
+
+| Path | Method | Purpose |
+|------|--------|---------|
+| `/v1/feedback` | POST | Submit a rating (1 = thumbs-up, -1 = thumbs-down) |
+| `/v1/feedback` | GET | Query records, filterable by `trace_id`, `session_id`, time window |
+| `/v1/feedback/stats` | GET | Aggregated counts grouped by time window (`hour` / `day` / `week`) |
+
+A minimal POST looks like this:
+
+```bash
+curl -X POST http://my-agent:8080/v1/feedback \
+  -H 'Content-Type: application/json' \
+  -d '{"trace_id":"trace_abc123","rating":1,"comment":"clear explanation"}'
+```
+
+`trace_id` is optional -- if omitted, the server synthesises a stand-alone
+identifier so feedback works even when tracing is disabled or sampled
+out. Records keyed to a real trace can be joined to the trace store;
+orphan records are still useful as raw rating data.
+
+#### Where the trace_id comes from
+
+Every chat completion response now carries an `X-Trace-Id` header (sync
+and streaming) and a top-level `trace_id` field on the final SSE usage
+chunk. UI clients capture either value and attach it to subsequent
+feedback POSTs. The gateway preserves the value verbatim:
+
+```
+Browser  ──POST /v1/feedback──▶  UI proxy  ──▶  Gateway  ──▶  Agent
+                                                  └─ forwards Authorization,
+                                                     X-User-ID for attribution
+```
+
+#### UI integration
+
+The chat UI scaffolded by `fips-agents create ui` includes thumbs-up /
+thumbs-down icons that hover-reveal on completed assistant messages.
+Thumbs-up records a positive rating immediately. Thumbs-down opens a
+small modal asking for a category (Inaccurate / Not helpful / Harmful /
+Too long / Other) plus an optional free-text comment, then POSTs to
+`/v1/feedback` via the gateway. Categories are encoded as a bracketed
+prefix on the comment field (`[Inaccurate] verbose detail`) so they
+round-trip through the existing schema and remain recoverable from
+queries.
+
+#### Querying feedback
+
+List the most recent records for a session:
+
+```bash
+curl 'http://my-agent:8080/v1/feedback?session_id=demo-1&limit=20' | jq
+```
+
+Get aggregated stats for the last 7 days, bucketed by day:
+
+```bash
+curl 'http://my-agent:8080/v1/feedback/stats?window=day&since=2026-04-19T00:00:00Z' | jq
+```
+
+Each stats row contains `window_start`, `window_end`, `agent_type`,
+`thumbs_up`, `thumbs_down`, and `total`. Pipe these to your analytics
+stack -- a Grafana panel keyed off the SQLite or Postgres backend is
+typical.
+
+#### Lab exercise
+
+Enable feedback on the calculus agent with sqlite storage:
+
+1. Set `server.feedback.enabled: true` and `server.storage.backend: sqlite`
+   in `agent.yaml`.
+2. Add `fipsagents[feedback]` to the `dependencies` list in
+   `pyproject.toml` (or run `pip install 'fipsagents[feedback]'` in your
+   venv).
+3. Redeploy: `make deploy PROJECT=calculus-agent`.
+4. Open the chat UI, run several conversations, click thumbs-up on good
+   answers and thumbs-down (with a category) on bad ones.
+5. Query `/v1/feedback/stats?window=hour` to see your ratings aggregated.
+6. Pick a low-rated trace and fetch it: `GET /v1/traces/{trace_id}` -- the
+   full conversation, tool calls, and timings are recoverable. That is
+   your first labelled training example.
+
 ## What's next
 
 You've built and hardened a complete AI agent system across eight modules:
@@ -445,7 +563,7 @@ You've built and hardened a complete AI agent system across eight modules:
 5. **Deployed** a gateway and chat UI for browser-based interaction
 6. **Added** a code execution sandbox for numerical computation
 7. **Extended** the agent with AI-assisted slash commands
-8. **Hardened** the stack with secrets, authentication, security policy, monitoring, and observability
+8. **Hardened** the stack with secrets, authentication, security policy, monitoring, observability, and user feedback collection
 
 The `calculus-agent/` and `calculus-helper/` directories in this repository
 serve as complete reference implementations. Use them as starting points for

--- a/docs/index.md
+++ b/docs/index.md
@@ -42,7 +42,7 @@ Browser → Chat UI → Gateway → Agent → MCP Server (calculus tools)
 | [5. Gateway and UI](05-gateway-and-ui.md) | Deploy the full stack, test end-to-end |
 | [6. Code Execution Sandbox](06-code-sandbox.md) | Deploy a sandbox, give the agent code execution |
 | [7. Extend with AI](07-extend-with-ai.md) | Use AI-assisted slash commands to add capabilities |
-| [8. Production Hardening](08-secrets-and-production.md) | Secrets, FIPS, scaling, observability (metrics, traces, sessions) |
+| [8. Production Hardening](08-secrets-and-production.md) | Secrets, FIPS, scaling, observability (metrics, traces, sessions, user feedback) |
 
 ## Reference
 

--- a/docs/reference/agent-yaml.md
+++ b/docs/reference/agent-yaml.md
@@ -29,6 +29,7 @@ Secrets to override defaults without editing the file.
 | `SESSIONS_ENABLED` | `server.sessions.enabled` | `false` | Enable session persistence |
 | `TRACES_ENABLED` | `server.traces.enabled` | `false` | Enable trace collection |
 | `METRICS_ENABLED` | `server.metrics.enabled` | `false` | Enable Prometheus metrics at `GET /metrics` |
+| `FEEDBACK_ENABLED` | `server.feedback.enabled` | `false` | Enable user feedback collection at `POST/GET /v1/feedback` |
 | `OTEL_ENDPOINT` | `server.traces.otel_endpoint` | -- | OTLP gRPC endpoint for trace export |
 | `OTEL_SERVICE_NAME` | `server.traces.service_name` | `fipsagents` | Service name for OTEL spans |
 | `MEMORY_BACKEND` | `memory.backend` | *(auto-detect)* | `memoryhub`, `sqlite`, `pgvector`, `custom`, `null` |
@@ -274,6 +275,28 @@ server:
   metrics:
     enabled: ${METRICS_ENABLED:-false}
 ```
+
+### server.feedback
+
+User feedback collection at `POST /v1/feedback`, `GET /v1/feedback`, and
+`GET /v1/feedback/stats`. Requires a storage backend for persistence;
+without one, POSTs are accepted and discarded.
+
+| Field | Type | Default | Description |
+|-------|------|---------|-------------|
+| `enabled` | bool | `false` | Enable feedback collection endpoints. |
+| `max_age_hours` | int | `720` | Records expire after this many hours (default: 30 days). |
+
+```yaml
+server:
+  feedback:
+    enabled: ${FEEDBACK_ENABLED:-false}
+    max_age_hours: 720
+```
+
+Records carry `rating` (`1` or `-1`), `trace_id` (for joining to trace
+data), optional `comment` and `correction`, plus `model_id`, `latency_ms`,
+`turn_index`, and `agent_type` for slicing in the stats endpoint.
 
 ## memory
 


### PR DESCRIPTION
## Summary

Adds the user-feedback teaching material to module 8 (Production Hardening), where it slots naturally into the Observability section between trace collection and OTEL export.

The new \`### User feedback collection\` subsection covers:
- Why feedback matters (closes the loop, raw material for dashboards and RLHF)
- \`agent.yaml\` configuration (\`server.feedback\`)
- The three REST endpoints with curl examples
- Where the \`trace_id\` comes from (\`X-Trace-Id\` header / SSE usage chunk)
- UI integration (thumbs icons, modal, category encoding)
- Querying records and stats
- A six-step lab exercise that wires the full loop on the calculus agent

Reference page \`reference/agent-yaml.md\` gets a new \`server.feedback\` table and the \`FEEDBACK_ENABLED\` env-var entry. \`index.md\` and the module-8 closing recap mention user feedback alongside the other observability features.

Closes fips-agents/examples#13. Companion to fips-agents/agent-template#109 (FeedbackStore), #110 (trace_id surfacing), #111 (scaffolding), fips-agents/gateway-template#20, and fips-agents/ui-template#23.

## Test plan

- [x] \`mkdocs build --strict\` passes (no broken links)
- [ ] Visual review on the rendered site after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)