### PR TITLE
docs: reframe fips-agents as a toolkit, not a framework

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,12 +4,12 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 ## What this repo is
 
-A **tutorial repository** that teaches building, deploying, and extending AI agents on OpenShift using the [fips-agents](https://github.com/fips-agents) framework. It is _not_ application code — it is published documentation plus two completed worked examples.
+A **tutorial repository** that teaches building, deploying, and extending AI agents on OpenShift using the [fips-agents](https://github.com/fips-agents) toolkit (a scaffolding CLI plus composable templates — not a framework). It is _not_ application code — it is published documentation plus two completed worked examples.
 
 Three top-level concerns coexist here:
 
 1. **MkDocs tutorial site** (`docs/`, `mkdocs.yml`) — published to https://fips-agents.github.io/examples/ via `.github/workflows/pages.yml` on every push to `main`.
-2. **`calculus-agent/`** — finished BaseAgent-framework agent (the "Module 1–9" worked example). Has its own `CLAUDE.md` with framework-specific guidance.
+2. **`calculus-agent/`** — finished BaseAgent-based agent (the "Module 1–9" worked example). Has its own `CLAUDE.md` with BaseAgent-specific guidance.
 3. **`calculus-helper/`** — finished FastMCP v3 server providing 8 SymPy-powered calculus tools. Has its own `CLAUDE.md` with FastMCP-specific guidance.
 
 When working inside `calculus-agent/` or `calculus-helper/`, that sub-project's `CLAUDE.md` is authoritative — it covers the agent or MCP server's structure, decorators, deployment, and common mistakes. This top-level file is only for cross-cutting tutorial-repo work.
@@ -32,7 +32,7 @@ The `--strict` flag is what GitHub Actions uses, so always reproduce CI behavior
 
 - Modules 1–9 live in `docs/0N-*.md` and are referenced by number in cross-links.
 - Reference pages live in `docs/reference/` and are linked from multiple modules.
-- The tutorial pins a specific framework version (currently fipsagents v0.11.0 — see `docs/index.md`). Bumping that version requires a coordinated re-test of every module.
+- The tutorial pins a specific fipsagents version (currently v0.11.0 — see `docs/index.md`). Bumping that version requires a coordinated re-test of every module.
 
 When fixing issues found by tutorial walk-throughs, file them at `fips-agents/examples` on GitHub and link the issue from the commit.
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Building AI Agents on Red Hat AI
 
-A hands-on tutorial for building, deploying, and extending AI agents on **Red Hat AI** (OpenShift AI on OpenShift) using the [fips-agents](https://github.com/fips-agents) framework.
+A hands-on tutorial for building, deploying, and extending AI agents on **Red Hat AI** (OpenShift AI on OpenShift) using the [fips-agents](https://github.com/fips-agents) toolkit.
 
 **[Start the tutorial](https://fips-agents.github.io/examples/)**
 

--- a/docs/01-scaffold-agent.md
+++ b/docs/01-scaffold-agent.md
@@ -207,7 +207,7 @@ appends all rules from `rules/`, and appends the skill manifest from
 
 ## The tool system
 
-The framework uses a **two-plane** model for tools:
+BaseAgent uses a **two-plane** model for tools:
 
 | Plane | Visibility | Who calls it | Example |
 |-------|-----------|-------------|---------|

--- a/docs/04-wire-mcp-to-agent.md
+++ b/docs/04-wire-mcp-to-agent.md
@@ -18,7 +18,7 @@ Before diving in, here's the full picture of what you're about to do:
 | `tools/web_search.py` | Delete | No longer needed -- real tools come from MCP |
 
 Everything else -- the Helm chart, the Containerfile, the Makefile, the
-framework code -- stays untouched. That's the power of the architecture: swap
+fipsagents code -- stays untouched. That's the power of the architecture: swap
 tools by changing config, not plumbing.
 
 ## Connect the MCP server
@@ -112,7 +112,7 @@ available to you: integration and differentiation.
 
 Three things to notice about this prompt:
 
-**It doesn't list tool names or schemas.** The framework injects tool schemas
+**It doesn't list tool names or schemas.** BaseAgent injects tool schemas
 automatically when building the system message. The prompt just describes the
 *domain* and the *behavior* -- the model discovers the specifics from the
 schemas.

--- a/docs/07-extend-with-ai.md
+++ b/docs/07-extend-with-ai.md
@@ -191,7 +191,7 @@ The key additions to the `## Instructions` section:
 ```
 
 !!! info "The prompt describes capabilities, not schemas"
-    The framework injects tool schemas into the system message at runtime.
+    BaseAgent injects tool schemas into the system message at runtime.
     The prompt's job is to describe the domain, guide tool selection, and set
     behavioral expectations. It shouldn't duplicate what the schemas already
     communicate.

--- a/docs/08-secrets-and-production.md
+++ b/docs/08-secrets-and-production.md
@@ -36,7 +36,7 @@ the host kernel does not have FIPS enabled.
 
 ## The litellm migration
 
-The framework originally used **litellm** as an LLM abstraction layer. Two
+The agent runtime originally used **litellm** as an LLM abstraction layer. Two
 problems forced a switch:
 
 1. **FIPS incompatibility.** litellm's dependency tree pulls in cryptographic
@@ -321,7 +321,7 @@ typically doesn't need a longer timeout since it serves static assets.
 
 ## Observability
 
-The framework includes built-in observability features for production
+The agent runtime includes built-in observability features for production
 deployments: session persistence, Prometheus metrics, structured trace
 collection, and optional OpenTelemetry export. All are configured through
 `agent.yaml` and share a common storage backend.

--- a/docs/09-file-uploads.md
+++ b/docs/09-file-uploads.md
@@ -37,7 +37,7 @@ questions whose answers come from the document's contents.
 | **Compliance review** | "Cross-check this contract against the policy library" |
 
 In every case the agent's job is the same: receive an opaque `file_id`,
-retrieve the extracted text, and reason over it. The framework handles
+retrieve the extracted text, and reason over it. The agent server handles
 everything between "user clicked attach" and "extracted text is ready".
 
 ## Configuring the agent server
@@ -100,7 +100,7 @@ A successful upload returns the JSON metadata record:
 ```
 
 Hold on to that `file_id`. Pass it back to `/v1/chat/completions` via the
-`file_ids` array, and the framework injects the file's extracted text into
+`file_ids` array, and the agent server injects the file's extracted text into
 the conversation before the LLM sees the user's message:
 
 ```bash
@@ -129,9 +129,9 @@ which converts a wide range of formats to clean Markdown:
 
 Parsing runs **inline** — the upload response only returns once
 `parse_status` is `completed` (or `failed`). For large documents this can
-take seconds. The framework runs Docling under `asyncio.to_thread` so it
+take seconds. The agent server runs Docling under `asyncio.to_thread` so it
 doesn't block the event loop, but if your typical upload is a 200-page PDF
-you'll want to consider background-queue parsing (a future framework
+you'll want to consider background-queue parsing (a future agent-server
 feature; see `agent-template#100`).
 
 `parse_status` transitions:
@@ -177,7 +177,7 @@ files:
 ```
 
 !!! warning "S3-compatible bytes backend is not yet shipped"
-    The framework keeps bytes on local FS regardless of the metadata
+    The agent server keeps bytes on local FS regardless of the metadata
     backend. An S3-compatible `BytesStore` ABC is on the roadmap. Until
     it lands, multi-replica deployments need a `ReadWriteMany` PVC or a
     sticky-session ingress to keep uploads consistent.
@@ -275,7 +275,7 @@ the agent container automatically when both `files.enabled` and
     The reference `clamav/clamav:stable` image ships clamd on TCP 3310 but
     does not expose the `{infected, viruses}` JSON contract on its own.
     Either build a custom image with a small FastAPI shim that wraps clamd,
-    or deploy a tiny adapter container alongside it. The framework's
+    or deploy a tiny adapter container alongside it. The agent server's
     contract is documented at
     `packages/fipsagents/src/fipsagents/server/scanner.py`.
 
@@ -402,7 +402,7 @@ curl http://localhost:8080/v1/chat/completions \
 ```
 
 The agent answers using the document's content. No tool call was needed —
-the framework injected the extracted text before the LLM saw the prompt.
+the agent server injected the extracted text before the LLM saw the prompt.
 
 **Step 4: Verify the security controls**
 

--- a/docs/guides/serve-an-llm.md
+++ b/docs/guides/serve-an-llm.md
@@ -5,7 +5,7 @@ reference model is **`ibm-granite/granite-3.3-8b-instruct`** served via
 **vLLM**. Granite 3.3 8B is small enough to fit on a single 24 GB GPU at
 fp16, capable enough to drive multi-turn tool calls reliably, and works
 well in FIPS mode — useful since this tutorial targets the `fips-agents`
-framework.
+toolkit.
 
 This guide covers two paths:
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -2,7 +2,7 @@
 
 A hands-on tutorial that takes you from zero to a deployed AI agent system
 on **Red Hat AI**, using the [fips-agents](https://github.com/fips-agents)
-framework.
+toolkit.
 
 This tutorial was last verified against **fipsagents v0.11.0** (April 2026).
 

--- a/docs/reference/agent-yaml.md
+++ b/docs/reference/agent-yaml.md
@@ -63,7 +63,7 @@ OpenAI-compatible `/v1` URL -- vLLM, LlamaStack, llm-d, or any compatible API.
 |-------|------|---------|-------------|
 | `endpoint` | string | `http://llamastack:8321/v1` | OpenAI-compatible API base URL. |
 | `name` | string | `meta-llama/Llama-3.3-70B-Instruct` | Model identifier passed to the endpoint. |
-| `provider` | string | `openai` | LLM backend. Valid values: `openai` (any OpenAI-compatible endpoint -- default), `anthropic`, `bedrock`, `bedrock-converse`, `azure`, `openai-compatible`, `ollama`, `llama-cpp`, `vertex`. When provider is non-openai, the framework auto-rewrites the endpoint to the LLM adapter sidecar at `localhost:8081/v1`. |
+| `provider` | string | `openai` | LLM backend. Valid values: `openai` (any OpenAI-compatible endpoint -- default), `anthropic`, `bedrock`, `bedrock-converse`, `azure`, `openai-compatible`, `ollama`, `llama-cpp`, `vertex`. When provider is non-openai, the agent runtime auto-rewrites the endpoint to the LLM adapter sidecar at `localhost:8081/v1`. |
 | `temperature` | float | `0.7` | Sampling temperature. |
 | `max_tokens` | int | `4096` | Maximum tokens per completion. |
 

--- a/docs/reference/baseagent-api.md
+++ b/docs/reference/baseagent-api.md
@@ -1,6 +1,6 @@
 # BaseAgent API
 
-Complete method reference for `BaseAgent`, the framework class your agent
+Complete method reference for `BaseAgent`, the base class your agent
 subclasses. Import it from `fipsagents.baseagent`:
 
 ```python

--- a/docs/reference/makefile.md
+++ b/docs/reference/makefile.md
@@ -148,18 +148,23 @@ make clean PROJECT=calculus-demo
 
 | Target | Description | When to use |
 |--------|-------------|-------------|
-| `vendor` | Vendor fipsagents source into the project | Switching from PyPI to a local copy of the framework (agent only) |
-| `update-framework` | Update vendored fipsagents to latest upstream | After a framework release (agent only) |
+| `vendor` | Vendor fipsagents source into the project | Switching from PyPI to a local copy of fipsagents (agent only) |
+| `update-fipsagents` | Update vendored fipsagents to latest upstream | After a fipsagents release (agent only) |
 
 ```bash
 make vendor             # initial vendoring
-make update-framework   # pull latest changes
+make update-fipsagents  # pull latest changes
 ```
 
+!!! note "Renamed from `update-framework`"
+    The target was renamed from `update-framework` to `update-fipsagents` to
+    match the package being updated. The old name is kept as a deprecated
+    alias and will be removed in a future release.
+
 These targets call `fips-agents vendor` under the hood. Vendoring copies the
-framework source into `src/fipsagents/` so the project has no PyPI dependency
+fipsagents source into `src/fipsagents/` so the project has no PyPI dependency
 on fipsagents at runtime. This is useful for air-gapped deployments or when you
-need to pin a specific framework version.
+need to pin a specific fipsagents version.
 
 ## Quick reference
 
@@ -179,7 +184,7 @@ All targets in a single table for quick scanning.
 | `deploy` | yes | yes | Deploy to OpenShift |
 | `redeploy` | yes | -- | Force-redeploy |
 | `clean` | yes | yes | Remove from OpenShift |
-| `vendor` | yes | -- | Vendor framework source |
-| `update-framework` | yes | -- | Update vendored framework |
+| `vendor` | yes | -- | Vendor fipsagents source |
+| `update-fipsagents` | yes | -- | Update vendored fipsagents |
 
 The MCP server also defines a `dev` alias that maps to `run-local`.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,5 +1,5 @@
 site_name: "Building AI Agents on Red Hat AI"
-site_description: "A hands-on tutorial for building, deploying, and extending AI agents on Red Hat AI using the fips-agents framework"
+site_description: "A hands-on tutorial for building, deploying, and extending AI agents on Red Hat AI using the fips-agents toolkit"
 site_url: https://fips-agents.github.io/examples/
 repo_url: https://github.com/fips-agents/examples
 repo_name: fips-agents/examples


### PR DESCRIPTION
## Summary

- Top-level positioning: "the fips-agents framework" → "the fips-agents toolkit" across README, mkdocs.yml, CLAUDE.md, index.md, and the LLM-serving guide.
- In-line runtime references replaced with the actual subject:
  - **BaseAgent** for tool schema injection, the two-plane tool model, the base class itself
  - **agent runtime** for litellm/observability, endpoint rewriting
  - **agent server** for file uploads, parsing, bytes storage, scanner contract
- "Framework version/release" → "fipsagents version/release".
- Updates the Makefile reference for the rename of `update-framework` → `update-fipsagents` (depends on fips-agents/agent-template#150; old name remains as a deprecated alias upstream).

The `xml-analysis-framework` external project name is untouched.

## Why

fips-agents-cli is a scaffolding/composition CLI plus templates — it generates code and gets out of the way. There is no fips-agents runtime that owns your project's lifecycle, so calling it a "framework" sets the wrong expectation. The pieces that *are* framework-ish (BaseAgent, the agent server) are named explicitly where they apply, instead of hiding behind a generic "framework".

## Test plan

- [x] `mkdocs build --strict` passes
- [x] No remaining unintentional "framework" references (only `xml-analysis-framework` and the deliberate "not a framework" clarification in CLAUDE.md remain)
- [ ] Visual review of the rendered site