### PR TITLE
docs: Module 10/11 (platform mode + llm-d) and e2e drift fixes

### DIFF
--- a/docs/01-scaffold-agent.md
+++ b/docs/01-scaffold-agent.md
@@ -104,6 +104,20 @@ mcp_servers:
     args: [--verbose]
 ```
 
+### Platform mode (optional, off by default)
+
+```yaml
+platform:
+  enabled: ${PLATFORM_MODE:-false}
+  endpoint: ${OGX_ENDPOINT:-}
+```
+
+Off by default. When enabled, the agent delegates LLM orchestration to
+[OGX](https://ogx-ai.github.io/) — including MCP tool calls, shield
+enforcement, and the inference loop — instead of running them client-side.
+We cover this in [Module 10](10-guardrails-and-observability.md); leave it
+off until then.
+
 ### Local tools and server
 
 ```yaml
@@ -124,14 +138,13 @@ endpoint that the gateway and UI communicate through.
 
 ## Understanding src/agent.py
 
-The template gives you a `ResearchAssistant` that demonstrates all three
-model-calling patterns (`call_model`, `call_model_json`,
-`call_model_validated`). Here's the essential shape:
+The template gives you a `MyAgent` class with the minimal shape — one model
+call, optional tool dispatch, return:
 
 ```python
 from fipsagents.baseagent import BaseAgent, StepResult
 
-class ResearchAssistant(BaseAgent):
+class MyAgent(BaseAgent):
     async def step(self) -> StepResult:
         response = await self.call_model()
         response = await self.run_tool_calls(response)
@@ -149,6 +162,8 @@ reasoning. `call_model()` sends the conversation to the LLM with all
 registered tool schemas. `run_tool_calls()` executes any tool calls the LLM
 requested and re-calls the model until no more tool calls remain.
 
+**Richer calling patterns** are documented in the project's `CLAUDE.md` ("Calling Patterns"): structured output via `call_model_json`, validation-with-retry via `call_model_validated`, and agent-code tool dispatch via `self.use_tool()`. The minimal `step()` above is enough for the rest of this tutorial.
+
 **The `__main__` block.** Starts the agent as an HTTP server:
 
 ```python
@@ -158,7 +173,7 @@ if __name__ == "__main__":
 
     config = load_config("agent.yaml")
     server = OpenAIChatServer(
-        agent_class=ResearchAssistant,
+        agent_class=MyAgent,
         config_path="agent.yaml",
         title=config.agent.name,
         version=config.agent.version,
@@ -178,26 +193,28 @@ The system prompt uses **Markdown with YAML frontmatter**:
 ```markdown
 ---
 name: system
-description: System prompt for the Research Assistant agent
+description: System prompt for the agent
 temperature: 0.3
 variables:
-  - name: max_results
-    type: integer
-    description: Maximum number of search results to consider
-    default: "5"
+  - name: role
+    type: string
+    description: One-line role description used to focus the agent
+    default: "a helpful assistant"
 ---
 
-You are a Research Assistant. Your job is to answer questions thoroughly
-and accurately by searching for information and synthesizing what you find.
+You are {role}.
 
 ## Instructions
 
-1. When given a research question, use the `web_search` tool to find
-   relevant information...
+1. Use the tools available to you to accomplish the user's request.
+2. If the request is ambiguous, ask a clarifying question before acting.
+3. If you cannot complete the request, say so explicitly rather than
+   speculating.
 ```
 
 The frontmatter declares metadata and template variables. Variables use
-`{variable_name}` syntax and are substituted when loaded.
+`{variable_name}` syntax and are substituted when loaded. We'll replace this
+generic prompt with one tailored to the calculus domain in Module 4.
 
 The `prompts.system` field in `agent.yaml` designates which prompt file
 becomes the system prompt (defaults to `system`, which loads
@@ -301,24 +318,30 @@ curl localhost:8080/v1/agent-info | python -m json.tool
         "version": "0.1.0"
     },
     "model": {
-        "endpoint": "...",
-        "name": "..."
+        "name": "meta-llama/Llama-3.3-70B-Instruct",
+        "temperature": 0.7,
+        "max_tokens": 4096
     },
-    "tools": ["code_executor", "web_search"]
+    "system_prompt": "You are a helpful assistant.\n\n## Instructions\n...",
+    "tools": []
 }
 ```
 
-!!! warning "The mock tools"
-    The template ships with a `web_search` tool that returns fake results and
-    a `code_executor` that requires a sandbox sidecar (not running locally by
-    default). This is intentional -- it lets you verify the agent starts and
-    responds without external dependencies. We'll replace these with real
-    calculus tools in Modules 3 and 4.
+The `tools` array is a list of objects (`{name, description, parameters}`)
+when tools are registered, and `system_prompt` reflects the rendered prompt
+text after rule and skill injection.
+
+!!! note "MemoryHub log line"
+    On first start you'll see `MemoryHub config at .memoryhub.yaml has no
+    server_url — memory disabled (set server_url to enable).` That's expected
+    — the scaffold ships a stub `.memoryhub.yaml`, and the agent falls back
+    to `NullMemoryClient` cleanly. See `/add-memory` for wiring up real
+    memory later.
 
 Stop the server with `Ctrl+C`.
 
 ## What's next
 
-The scaffolded project runs, but it's still the generic Research Assistant with
-mock tools. In [Module 2](02-configure-and-deploy.md), you'll customize the
-configuration, point it at a real LLM on your OpenShift cluster, and deploy it.
+The scaffolded project runs but is still generic. In
+[Module 2](02-configure-and-deploy.md), you'll customize the configuration,
+point it at a real LLM on your OpenShift cluster, and deploy it.

--- a/docs/04-wire-mcp-to-agent.md
+++ b/docs/04-wire-mcp-to-agent.md
@@ -15,7 +15,6 @@ Before diving in, here's the full picture of what you're about to do:
 | `agent.yaml` | Add `mcp_servers:` entry | Tell the agent where to find the MCP server |
 | `prompts/system.md` | Rewrite for calculus domain | Tell the model what it is and what tools it has |
 | `src/agent.py` | Rename class for calculus domain | Update identity to match the new purpose |
-| `tools/web_search.py` | Delete | No longer needed -- real tools come from MCP |
 
 Everything else -- the Helm chart, the Containerfile, the Makefile, the
 fipsagents code -- stays untouched. That's the power of the architecture: swap
@@ -62,29 +61,19 @@ discovers the available tools, and registers them with `llm_only` visibility.
 The LLM sees them alongside any local tools -- it doesn't know or care which
 are local and which are remote.
 
-## Remove the mock tool
+## Local tools and MCP tools coexist
 
-The scaffolded project shipped with a `tools/web_search.py` placeholder. The
-calculus agent doesn't need it -- all its tools come from MCP. Delete it:
-
-```bash
-rm tools/web_search.py
-```
-
-If there are other example tools (like `format_citations.py` or
-`code_executor.py`), remove those too. The `tools/` directory can be empty, or
-you can keep it around for future local tools.
-
-!!! note "Local tools and MCP tools coexist"
-    Deleting `web_search.py` is a cleanup step, not a requirement. Local tools
-    and MCP-discovered tools coexist in the same registry. If you later need a
-    tool that's specific to this agent and doesn't belong in a shared MCP
-    server, add it back to `tools/`.
+Recent template versions ship `tools/` empty by default — your calculus
+agent's tools all come from MCP at this point. If your scaffold has any
+example tool files left over, you can delete them, but they don't have to
+go: local tools and MCP-discovered tools coexist in the same registry. If
+you later need a tool that's specific to this agent and doesn't belong in a
+shared MCP server, add it to `tools/`.
 
 ## Update the system prompt
 
-Open `prompts/system.md` and replace the Research Assistant prompt with one
-tailored to the calculus domain:
+Open `prompts/system.md` and replace the generic role-templated prompt with
+one tailored to the calculus domain:
 
 ```markdown
 ---

--- a/docs/05-gateway-and-ui.md
+++ b/docs/05-gateway-and-ui.md
@@ -180,6 +180,15 @@ injected into the frontend JavaScript.
 
 ## Deploy the gateway
 
+!!! tip "Set `$CTX` to your kubeconfig context name"
+    Module 5 passes `--kube-context="$CTX"` and `--context="$CTX"` on every
+    `helm` and `oc` invocation. Set it once before you start so we don't
+    quietly mutate the active project on a shared kubeconfig:
+
+    ```bash
+    export CTX=$(oc config current-context)
+    ```
+
 Build and deploy the gateway to your namespace:
 
 ```bash
@@ -197,8 +206,15 @@ agent's in-cluster service URL:
 helm upgrade calculus-gateway chart/ \
   --set config.BACKEND_URL=http://calculus-agent:8080 \
   --reuse-values \
-  -n calculus-agent --kube-context=fips-rhoai
+  -n calculus-agent --kube-context="$CTX"
+
+# Roll the pod so it picks up the new ConfigMap
+oc rollout restart deployment/calculus-gateway -n calculus-agent --context="$CTX"
+oc rollout status deployment/calculus-gateway -n calculus-agent --context="$CTX"
 ```
+
+!!! warning "Why the explicit rollout restart"
+    Until [gateway-template#37](https://github.com/fips-agents/gateway-template/issues/37) lands, the gateway chart's Deployment template is missing a `checksum/config` annotation. That means `helm upgrade --reuse-values --set config.X=Y` updates the ConfigMap, but Kubernetes doesn't see a deployment change and the pod keeps its stale env vars. The gateway will return 502 to clients (it's still pointed at the chart-default backend) until you restart it. The same caveat applies to the UI deploy below; once the upstream fix lands, you can drop the `oc rollout restart` lines.
 
 !!! note "In-cluster service DNS"
     `http://calculus-agent:8080` uses Kubernetes short-name DNS. This works
@@ -210,7 +226,7 @@ helm upgrade calculus-gateway chart/ \
 Verify the gateway is proxying correctly:
 
 ```bash
-GW_ROUTE=$(oc get route calculus-gateway -n calculus-agent --context=fips-rhoai -o jsonpath='{.spec.host}')
+GW_ROUTE=$(oc get route calculus-gateway -n calculus-agent --context="$CTX" -o jsonpath='{.spec.host}')
 
 # Health check (gateway's own endpoint)
 curl -sk "https://$GW_ROUTE/healthz"
@@ -226,31 +242,23 @@ gateway pod --> agent service --> agent pod.
 
 ## Deploy the UI
 
-The UI scaffold doesn't include a `build-openshift` Makefile target, so you
-create the BuildConfig directly and build from source:
-
 ```bash
 cd calculus-ui
-oc new-build --binary --name=calculus-ui --strategy=docker \
-  -n calculus-agent --context=fips-rhoai
-oc patch bc/calculus-ui --patch '{"spec":{"strategy":{"dockerStrategy":{"dockerfilePath":"Containerfile"}}}}' \
-  -n calculus-agent --context=fips-rhoai
-oc start-build calculus-ui --from-dir=. --follow \
-  -n calculus-agent --context=fips-rhoai
+make build-openshift PROJECT=calculus-agent
+make deploy PROJECT=calculus-agent
 ```
 
-Once the image is built, deploy the Helm chart and point `API_URL` at the
-gateway's **in-cluster** service URL:
+Then set `API_URL` to point at the gateway's **in-cluster** service URL:
 
 ```bash
-IMAGE=$(oc get is calculus-ui -n calculus-agent --context=fips-rhoai \
-  -o jsonpath='{.status.dockerImageRepository}')
-
-helm upgrade --install calculus-ui chart/ \
-  --set image.repository=$IMAGE \
-  --set image.tag=latest \
+helm upgrade calculus-ui chart/ \
   --set config.API_URL=http://calculus-gateway:8080 \
-  -n calculus-agent --kube-context=fips-rhoai
+  --reuse-values \
+  -n calculus-agent --kube-context="$CTX"
+
+# Roll the pod (see the gateway-template#37 caveat above)
+oc rollout restart deployment/calculus-ui -n calculus-agent --context="$CTX"
+oc rollout status deployment/calculus-ui -n calculus-agent --context="$CTX"
 ```
 
 !!! info "In-cluster URL, not external route"
@@ -269,7 +277,7 @@ helm upgrade --install calculus-ui chart/ \
 Get the UI route and open it in your browser:
 
 ```bash
-UI_ROUTE=$(oc get route calculus-ui -n calculus-agent --context=fips-rhoai -o jsonpath='{.spec.host}')
+UI_ROUTE=$(oc get route calculus-ui -n calculus-agent --context="$CTX" -o jsonpath='{.spec.host}')
 echo "https://$UI_ROUTE"
 ```
 
@@ -283,12 +291,12 @@ at the edge. You need to raise it on both the gateway and UI routes.
 # Set 120-second timeout on the gateway route
 oc annotate route calculus-gateway \
   haproxy.router.openshift.io/timeout=120s \
-  --overwrite -n calculus-agent --context=fips-rhoai
+  --overwrite -n calculus-agent --context="$CTX"
 
 # Set 120-second timeout on the UI route
 oc annotate route calculus-ui \
   haproxy.router.openshift.io/timeout=120s \
-  --overwrite -n calculus-agent --context=fips-rhoai
+  --overwrite -n calculus-agent --context="$CTX"
 ```
 
 !!! warning "The silent 504"
@@ -330,9 +338,9 @@ If any request hangs or times out, check the route timeout annotation first.
 Then check pod logs for each component in the chain:
 
 ```bash
-oc logs deployment/calculus-ui -n calculus-agent --context=fips-rhoai --tail=20
-oc logs deployment/calculus-gateway -n calculus-agent --context=fips-rhoai --tail=20
-oc logs deployment/calculus-agent -n calculus-agent --context=fips-rhoai --tail=20
+oc logs deployment/calculus-ui -n calculus-agent --context="$CTX" --tail=20
+oc logs deployment/calculus-gateway -n calculus-agent --context="$CTX" --tail=20
+oc logs deployment/calculus-agent -n calculus-agent --context="$CTX" --tail=20
 ```
 
 ## Redeploying after changes
@@ -348,7 +356,7 @@ make deploy PROJECT=calculus-agent
 # UI
 cd calculus-ui
 oc start-build calculus-ui --from-dir=. --follow \
-  -n calculus-agent --context=fips-rhoai
+  -n calculus-agent --context="$CTX"
 make deploy PROJECT=calculus-agent
 ```
 

--- a/docs/06-code-sandbox.md
+++ b/docs/06-code-sandbox.md
@@ -44,16 +44,41 @@ somehow bypasses the import hook, it cannot reach external services.
     still protect you, and container resource limits remain your primary
     defense against resource exhaustion.
 
+## Build the sandbox image
+
+The sandbox is maintained as its own project at
+[fips-agents/code-sandbox](https://github.com/fips-agents/code-sandbox).
+Clone it and build the image into your `calculus-agent` namespace via
+BuildConfig — same pattern as the agent and the MCP server:
+
+```bash
+gh repo clone fips-agents/code-sandbox
+cd code-sandbox
+
+oc new-build --binary --name=code-sandbox --strategy=docker \
+  -n calculus-agent --context="$CTX"
+oc patch bc/code-sandbox --type=json \
+  -p '[{"op":"replace","path":"/spec/strategy/dockerStrategy/dockerfilePath","value":"Containerfile"}]' \
+  -n calculus-agent --context="$CTX"
+oc start-build code-sandbox --from-dir=. --follow \
+  -n calculus-agent --context="$CTX"
+```
+
+The build takes 2–3 minutes and pushes
+`image-registry.openshift-image-registry.svc:5000/calculus-agent/code-sandbox:latest`
+to the cluster's internal registry.
+
 ## Enable the sandbox in your Helm chart
 
 The sandbox is configured as an optional sidecar in the agent's Helm chart.
-Open `chart/values.yaml` and add the `sandbox` section:
+Open `chart/values.yaml` and add the `sandbox` section, pointing
+`image.repository` at the image stream you just built:
 
 ```yaml
 sandbox:
   enabled: true
   image:
-    repository: code-sandbox
+    repository: image-registry.openshift-image-registry.svc:5000/calculus-agent/code-sandbox
     tag: latest
   resources:
     limits:

--- a/docs/10-guardrails-and-observability.md
+++ b/docs/10-guardrails-and-observability.md
@@ -1,0 +1,287 @@
+# 10. Platform Mode and Guardrails
+
+Modules 1–9 are about *building* the agent: scaffolding, tools, MCP, deployment, hardening, file uploads. Module 10 is about *graduating concerns to the platform* — moving tool orchestration, safety enforcement, and inference-loop telemetry out of the agent's code and into a server that owns those things on the cluster. The agent gets simpler. The platform takes responsibility for what the agent should not have to know about.
+
+The platform here is **OGX** — the rebrand of LlamaStack — an OpenAI-compatible AI application server. Instead of the agent calling vLLM directly and running its own MCP tool loop, the agent calls OGX's [Responses API](https://ogx-ai.github.io/docs/api), and OGX handles the loop, the MCP, and the shields server-side.
+
+!!! tip "Prerequisite: fipsagents 0.21+"
+    The tutorial baseline is fipsagents 0.11.0; platform mode requires **0.21.0 or later**. If you've been following Modules 1–9 with the baseline, bump now:
+
+    ```bash
+    cd calculus-agent
+    pip install --upgrade 'fipsagents>=0.21'
+    ```
+
+    Modules 1–9 still work on 0.21+ unchanged — this is a forward-compatible bump.
+
+## What changes
+
+```
+Before (Modules 1–9)                    After (Module 10)
+
+Browser → UI → Gateway → Agent          Browser → UI → Gateway → Agent
+                            │                                       │
+                            ├─→ vLLM                                 └─→ OGX ──┬─→ vLLM
+                            │                                                  │
+                            └─→ MCP server                                     ├─→ MCP server
+                                                                               │
+                                                                               └─→ Llama Guard /
+                                                                                   code-scanner
+```
+
+Three things move:
+
+| Concern | Module 1–9 (agent-side) | Module 10 (platform-side) |
+|---------|-------------------------|---------------------------|
+| Tool loop | `step()` runs `while response.tool_calls:` client-side | OGX runs the loop server-side; agent sends one Responses request per turn |
+| MCP wiring | `agent.yaml::mcp_servers` → FastMCP client per server | OGX `config.yaml` → MCP connector; agent passes the name |
+| Shield enforcement | None (or implemented by hand in `step()`) | `guardrails: ["..."]` on the Responses request; OGX blocks on violation |
+
+Tracing comes along for the ride: OGX emits OpenTelemetry spans for inference, MCP tool calls, and shield evaluations without any agent-side instrumentation.
+
+## Cluster prerequisites
+
+Three setup guides bring the cluster up to readiness. Run them in order, then come back here:
+
+1. **[Install OGX](guides/install-ogx.md)** — Operator + `OGXDistribution` pointing at your existing vLLM. Exports `OGX_ENDPOINT`.
+2. **[Configure Safety Shields](guides/configure-shields.md)** — register at least one shield (the built-in `code-scanner` is enough for this module). Exports `OGX_SHIELD`.
+3. **[Observability Backends](guides/observability-backends.md)** — Jaeger receiver for OGX's OTLP exports. Exports `JAEGER_UI`.
+
+You should have all three env vars set before continuing:
+
+```bash
+echo "$OGX_ENDPOINT $OGX_SHIELD $JAEGER_UI"
+```
+
+## Part 1: Switch the agent to platform mode
+
+Two file edits, no new code modules.
+
+### Update `agent.yaml`
+
+Recent template versions ship a stub `platform:` block (just `enabled` and `endpoint`). Expand it to register your MCP servers and shield IDs. Leave the existing `mcp_servers:` block in place — when `platform.enabled=true`, the framework ignores `mcp_servers:` and logs a notice; this keeps your `agent.yaml` rollback-safe.
+
+```yaml
+# agent.yaml — replace the existing platform: stub with this expanded form
+
+platform:
+  enabled: ${PLATFORM_MODE:-false}
+  endpoint: ${OGX_ENDPOINT:-}
+
+  # MCP servers OGX will orchestrate on the agent's behalf.
+  # Each entry needs `name` (becomes server_label on the wire) plus
+  # exactly one of `connector_id` (pre-registered in OGX config.yaml)
+  # or `url` (inline server_url passed per request).
+  mcp:
+    - name: calculus
+      url: ${MCP_CALCULUS_URL:-http://mcp-server.calculus-mcp.svc.cluster.local:8080/mcp/}
+
+  # Shield IDs registered in OGX. Empty list = no enforcement.
+  guardrails:
+    - ${OGX_SHIELD:-code-scanner}
+```
+
+The existing `model.endpoint` is still set to vLLM — keep it. The framework uses `platform.endpoint` for Responses calls and ignores `model.endpoint` when platform mode is on.
+
+!!! warning "`MODEL_NAME` also has to change"
+    OGX namespaces models by their inference-provider id, so a model that vLLM serves as `RedHatAI/gpt-oss-20b` is registered in OGX as `vllm/RedHatAI/gpt-oss-20b`. List your OGX server's models with `curl -s "$OGX_ENDPOINT/models" | jq` to find the prefixed form, and override `MODEL_NAME` accordingly when you redeploy below. The "URL change" framing isn't quite enough on its own — you also need to swap the model id.
+
+### Simplify `step()`
+
+The current `step()` runs a chat-completions request followed by a client-side tool loop:
+
+```python
+# src/agent.py — BEFORE
+async def step(self) -> StepResult:
+    response = await self.call_model()
+    response = await self.run_tool_calls(response)
+    return StepResult.done(response.content)
+```
+
+In platform mode, OGX runs the loop. `step()` becomes a single Responses call:
+
+```python
+# src/agent.py — AFTER
+async def step(self) -> StepResult:
+    response = await self.call_model_responses(self.messages)
+    if response.refusal:
+        return StepResult.done(response.refusal)
+    return StepResult.done(response.content or "")
+```
+
+`call_model_responses` defaults `tools` from `platform.mcp` and `guardrails` from `platform.guardrails`, so the call site is short. `PlatformResponse.refusal` is set when a shield fires; otherwise `.content` holds the joined assistant text.
+
+### Rebuild and redeploy
+
+```bash
+oc start-build calculus-agent --from-dir=. --follow -n calculus-agent --context="$CTX"
+
+oc set env deployment/calculus-agent -n calculus-agent --context="$CTX" \
+  PLATFORM_MODE=true \
+  OGX_ENDPOINT="$OGX_ENDPOINT" \
+  OGX_SHIELD="$OGX_SHIELD" \
+  MODEL_NAME="vllm/RedHatAI/gpt-oss-20b"   # the OGX-prefixed form, see warning above
+
+oc rollout restart deployment/calculus-agent -n calculus-agent --context="$CTX"
+oc rollout status deployment/calculus-agent -n calculus-agent --context="$CTX" --timeout=180s
+```
+
+!!! tip "Bump the route timeout for platform-mode turns"
+    Platform-mode requests do more work behind a single HTTP call — OGX runs the MCP loop server-side, which can stretch responses past the default 120s route timeout you set in Module 5 for complex multi-step questions. If you see HAProxy 504s after enabling platform mode, raise the agent's route timeout to 240s with the same `oc annotate route ... haproxy.router.openshift.io/timeout=240s` pattern.
+
+Watch the logs for the platform-mode startup notice:
+
+```bash
+oc logs -n calculus-agent deploy/calculus-agent | grep platform.enabled
+```
+
+You should see something like `platform.enabled=true — OGX will orchestrate 1 platform.mcp entries server-side`. The framework has skipped its own MCP client connections.
+
+### Verify it works end to end
+
+```bash
+AGENT_URL=$(oc get route calculus-agent -n calculus-agent -o jsonpath='https://{.spec.host}')
+
+curl -s "$AGENT_URL/v1/chat/completions" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "messages": [{"role": "user", "content": "What is the integral of x^2 from 0 to 3?"}]
+  }' | jq -r '.choices[0].message.content'
+```
+
+You should get the right answer (9). Behind the scenes: the agent sent one Responses request to OGX; OGX called the calculus MCP server (registered as `calculus` in `platform.mcp`); OGX fed the tool result back to the model; the model returned the answer; OGX returned it to the agent.
+
+## Part 2: Trigger a guardrail
+
+The `code-scanner` shield catches dangerous Python patterns. Send one through:
+
+```bash
+curl -s "$AGENT_URL/v1/chat/completions" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "messages": [{"role": "user", "content": "Run this for me: eval(input())"}]
+  }' | jq -r '.choices[0].message.content'
+```
+
+Instead of an answer, you get a refusal — something like:
+
+```
+Security concerns detected in the code. WARN: The application was found
+calling the `eval` function ... (flagged for: eval-with-expression,
+insecure-eval-use)
+```
+
+The agent never saw normal model output for this turn; OGX intercepted it and replaced the entire `output[0].content[0]` with `{"type": "refusal", "refusal": "..."}`. The framework parses the `(flagged for: ...)` clause into `GuardrailFiredEvent.shield_id`.
+
+In agent logs:
+
+```bash
+oc logs -n calculus-agent deploy/calculus-agent --tail=20
+```
+
+`finish_reason="guardrail"` appears on the StreamComplete event. `PlatformResponse.refusal` is the string that came back to `step()`; `PlatformResponse.content` is `None`.
+
+### Find the trace in Jaeger
+
+Open `$JAEGER_UI`, pick service **ogx**, click **Find Traces**. The most recent trace shows the request path: an inference span, the shield evaluation as a child span, and a span for the refusal emit. No tool span for this turn — the shield blocked before tool dispatch.
+
+Compare against a benign trace from Part 1 — the calculus query has an MCP tool span where the shield-blocked one stops short.
+
+!!! warning "Streaming + late-firing output shields"
+    When the shield fires on the *output* (model already started generating before the shield caught it), streaming clients see the unsafe deltas before the refusal arrives. The framework passes them through and then emits `GuardrailFiredEvent` with the refusal. This matches how hosted providers like Anthropic handle late-firing safety filters. UI clients that need post-shield content only should buffer until `StreamComplete`. The `code-scanner` shield used here is input-side, so this doesn't bite the tutorial — it bites real production deployments using output-side shields.
+
+## Part 3: References vs inline URLs
+
+The `platform.mcp` block in Part 1 used the inline form — every Responses request carries the calculus-helper URL. That works, but the URL still lives in the agent's config; moving the MCP server to a different namespace means an agent rebuild.
+
+OGX supports a second form: pre-register the MCP server once in OGX's `config.yaml` under a top-level `connectors:` block, then have the agent reference it by name. The URL becomes a platform concern entirely.
+
+The two forms are interchangeable in `agent.yaml`:
+
+```yaml
+# Inline form — agent owns the URL
+platform:
+  mcp:
+    - name: calculus
+      url: http://mcp-server.calculus-mcp.svc.cluster.local:8080/mcp/
+
+# Connector-reference form — OGX owns the URL
+platform:
+  mcp:
+    - name: calculus
+      connector_id: calculus
+```
+
+`PlatformMcpServer` validates that exactly one of `url` / `connector_id` is set, so the framework catches misconfigured entries at config-load time.
+
+The `connectors:` block syntax in OGX `config.yaml` varies by distribution version. The agent-side pattern is stable; if your platform team has registered MCP connectors centrally, ask them for the connector ID and use the reference form. Read what's currently registered with:
+
+```bash
+curl -s "$OGX_ENDPOINT/../v1beta/connectors" | jq
+```
+
+For the rest of this module, the inline form is fine — it's what the agent-template's live integration tests use.
+
+## Part 4: Moderation vs guardrails
+
+OGX exposes two separate safety surfaces — they answer different questions:
+
+| Surface | API | Behavior | Use for |
+|---------|-----|----------|---------|
+| **Guardrails** | `guardrails: [...]` on Responses | Enforces; blocks the request when a shield fires | Production safety: stop bad content from reaching users |
+| **Moderation** | `POST /v1/moderations` | Classifies; returns category scores; never blocks | Analytics, dashboards, audit logs: measure what's flowing through |
+
+`BaseAgent.moderate()` wraps the moderation endpoint:
+
+```python
+result = await self.moderate("This content might be sensitive.")
+# result.flagged: bool — OR of all category flags
+# result.categories: dict[str, bool] — eg {"violence": False, "self-harm": True}
+# result.category_scores: dict[str, float] — per-category confidence
+```
+
+A common pattern: keep guardrails enforcing in the request path, and run `moderate()` over the assistant's reply *after the fact* to populate dashboards. Because moderation never blocks, it's safe to call from any non-critical code path:
+
+```python
+async def step(self) -> StepResult:
+    response = await self.call_model_responses(self.messages)
+    if response.refusal:
+        return StepResult.done(response.refusal)
+    text = response.content or ""
+
+    # Audit-only — never blocks. Logs a structured line via the framework.
+    if text:
+        await self.moderate(text)
+
+    return StepResult.done(text)
+```
+
+The framework emits a structured log line for every `moderate()` call — `moderation: model=... flagged=... categories=[...]` — so even without a dashboard you get an audit trail.
+
+## What graduated, what stayed
+
+After Part 3, the agent owns:
+
+- The system prompt
+- Business logic in `step()`
+- Local tools, skills, rules, prompts
+
+The platform owns:
+
+- The inference loop
+- MCP tool dispatch
+- Shield enforcement
+- Tracing
+
+The same pattern applies to other concerns over time — memory, prompt management, eval. The shape is always the same: an `agent.yaml::platform.X` block, a framework method that delegates, a config block in OGX. The agent gets thinner each time.
+
+## Next
+
+[Module 11: Scaling Inference with llm-d](11-scaling-with-llm-d.md) covers what happens behind OGX when one vLLM is no longer enough.
+
+## Further reading
+
+- [agent-template#154](https://github.com/fips-agents/agent-template/issues/154) — design discussion that produced platform mode
+- [OGX Responses API](https://ogx-ai.github.io/docs/api/create-openai-response-v-1-responses-post)
+- [OGX safety shields](https://ogx-ai.github.io/docs/building_applications/safety)
+- [OGX moderations](https://ogx-ai.github.io/docs/api) — `/v1/moderations`

--- a/docs/11-scaling-with-llm-d.md
+++ b/docs/11-scaling-with-llm-d.md
@@ -1,0 +1,77 @@
+# 11. Scaling Inference with llm-d
+
+Module 10 graduated tool orchestration and safety to a platform layer (OGX). The remaining single point of contention in the architecture is the model server itself — one vLLM `InferenceService` behind OGX, serving every request. That works fine for a tutorial; in production it stops working as soon as you have more concurrent users than that vLLM can keep responsive, or as soon as you want a model larger than fits on a single accelerator.
+
+This chapter is conceptual — there's no agent code change, and no required step. Its job is to show you what fits behind OGX when one vLLM is no longer enough, so you know the next move when you outgrow Module 5's deployment.
+
+## Where the bottleneck lives
+
+LLM inference has two phases with very different resource profiles:
+
+- **Prefill** — the model reads the entire prompt once. Compute-heavy, runs in parallel across all input tokens, releases the GPU when the first output token is ready.
+- **Decode** — the model produces output tokens one at a time. Memory-bandwidth-bound, holds the GPU for the duration of the response.
+
+A single vLLM instance handles both on the same GPU. That means a long-prompt request stalls all other decode work behind it; a long-decode request blocks new prefills from starting. Worse, every replica recomputes the prefix cache for similar prompts independently — even when two requests share 90% of their system prompt, two GPUs do the prefill work twice.
+
+Horizontal autoscaling helps but doesn't solve these problems. Adding replicas adds capacity uniformly across both phases, when the actual contention is asymmetric and prefix-cache-shaped.
+
+## What llm-d does about it
+
+[llm-d](https://llm-d.ai) is a Kubernetes-native distributed inference framework built on vLLM. Three of its design choices change the picture:
+
+**Disaggregated prefill and decode.** Prefill workers and decode workers are separate Deployments with separate scaling rules. A prefill spike doesn't starve decoders; a long-decode request doesn't block new prefills.
+
+**KV-cache-aware routing.** A request whose prompt prefix already lives in some worker's cache gets routed to that worker, skipping the prefill recomputation. Hits compound under multi-tenant traffic, where many requests share system prompts, RAG context, or conversation history.
+
+**Hierarchical KV offloading.** Cache that doesn't fit on the GPU spills to host memory and (in v0.5+) further tiers, extending effective context capacity beyond accelerator VRAM.
+
+The architecture surfaces as an OpenAI-compatible HTTP endpoint — the same surface vLLM exposes, so anything that talks to vLLM today can talk to llm-d tomorrow.
+
+## Where it slots in
+
+The agent doesn't move. OGX doesn't even move much. Only the inference provider's URL changes:
+
+```
+After Module 10:                       After llm-d:
+
+Agent → OGX ──┬─→ vLLM (single)        Agent → OGX ──┬─→ llm-d gateway
+              │                                       │       │
+              ├─→ MCP                                 │       ├─→ prefill workers (N)
+              │                                       │       │
+              └─→ shields                             │       └─→ decode workers (M)
+                                                      │
+                                                      ├─→ MCP
+                                                      │
+                                                      └─→ shields
+```
+
+Inside the OGX `config.yaml` you authored in [Install OGX](guides/install-ogx.md), the `providers.inference[].config.url` field changes from your vLLM `InferenceService` URL to the llm-d gateway URL. Nothing else in OGX changes. Nothing in the agent changes — it never knew what was behind OGX in the first place. That's the payoff for the platform-layer work in Module 10.
+
+## When to reach for it
+
+llm-d is a meaningful operational lift — multiple Deployments, an inference scheduler, a separate routing layer. Don't deploy it because it sounds interesting. Reach for it when one or more of these is true:
+
+| Signal | Why llm-d helps |
+|--------|-----------------|
+| Sustained QPS exceeds what a single vLLM keeps responsive | Disaggregated workers + KV-cache routing absorb load that doesn't scale linearly with replicas |
+| Many users share long system prompts, RAG context, or conversation history | KV-cache-aware routing turns prefix overlap into actual prefill savings |
+| Model size approaches or exceeds single-accelerator VRAM | Hierarchical KV offloading extends effective context beyond GPU memory |
+| You're running multiple LoRA adapters | Cache-aware LoRA routing keeps adapter switching cheap |
+| Workload is bursty enough that you want scale-to-zero between traffic windows | v0.5+ supports it natively |
+
+If none of these apply yet, a single vLLM behind OGX is the right answer — and llm-d's payoff comes precisely because the rest of your stack doesn't have to know it exists when you do switch.
+
+## Getting started
+
+The llm-d project documents its own quickstart and Kubernetes install. Two pages worth bookmarking:
+
+- [llm-d.ai](https://llm-d.ai) — the project home, with the latest version and architecture overview
+- [github.com/llm-d/llm-d](https://github.com/llm-d/llm-d) — source, releases, and the Kubernetes deployment manifests
+
+When you're ready to test it without disturbing your tutorial deployment, point a *second* OGX `OGXDistribution` at the llm-d gateway, register it as a separate `provider_id` in the same OGX `config.yaml`, and shadow-route a percentage of traffic. The platform-mode design from Module 10 makes A/B comparison a config edit, not an architectural change.
+
+## What's next
+
+You've reached the end of the structured tutorial. The patterns you've built up — scaffolding agents with `fips-agents create`, exposing tools via MCP, hardening for production, graduating concerns to the platform — apply to any agent you want to build on Red Hat AI. The reference pages in the sidebar cover the configuration surface in depth when you need it.
+
+If you build something with this stack, file an issue or PR at [fips-agents/examples](https://github.com/fips-agents/examples) — the tutorial improves the most when it bumps into real-world problems we hadn't thought of.

--- a/docs/guides/configure-shields.md
+++ b/docs/guides/configure-shields.md
@@ -1,0 +1,225 @@
+# Configure Safety Shields
+
+Shields are OGX's enforcement layer — when an agent passes `guardrails: ["shield-id"]` on a Responses request, OGX runs the named shield against the input and the model output, and refuses the turn if the shield fires. Shields are registered server-side in OGX's `config.yaml`; agents only ever pass the ID.
+
+This guide covers two shield options:
+
+- **Path A — built-in `code-scanner`** (no extra model required). Right for the tutorial.
+- **Path B — Llama Guard via a second vLLM**. Production-grade content safety. Requires a second GPU.
+
+Both paths produce a registered shield ID that Module 10 reads from `OGX_SHIELD`.
+
+!!! note "Moderation vs guardrails"
+    OGX also exposes `/v1/moderations` for stateless content classification (returns category scores, never blocks). That is not a shield — Module 10 covers the difference. If all you want is "tell me what categories this content trips," you don't need to register a shield.
+
+## Prerequisites
+
+- OGX deployed per [Install OGX](install-ogx.md)
+- The `OGX_ENDPOINT` you exported there
+
+## Path A: built-in `code-scanner`
+
+The starter distribution ships an inline `code-scanner` provider that catches dangerous code patterns (`eval(input())`, raw `subprocess` shell, etc.) without calling any external model. It's the shield used in the agent-template's live integration tests, so we know it works against the upstream distribution.
+
+Edit the `ogx-config` ConfigMap from Install OGX:
+
+```bash
+oc edit configmap ogx-config -n ogx
+```
+
+Under `providers:`, add a `safety:` entry. Under the top-level `shields:`, register the shield ID:
+
+```yaml
+providers:
+  inference:
+    - provider_id: vllm
+      # ...unchanged...
+
+  safety:
+    - provider_id: code-scanner
+      provider_type: inline::code-scanner
+      config: {}
+
+  telemetry:
+    # ...unchanged...
+
+shields:
+  - shield_id: code-scanner
+    provider_id: code-scanner
+```
+
+If `inline::code-scanner` isn't recognized by your distribution, list what's actually available:
+
+```bash
+curl -s "$OGX_ENDPOINT/providers" | jq '.data[] | select(.api == "safety")'
+```
+
+The starter distribution registers `inline::code-scanner` and `inline::llama-guard` out of the box; you don't have to add them under `providers.safety:` — they're just waiting for a `shields:` entry to expose them.
+
+Roll the OGX pod to pick up the ConfigMap change:
+
+```bash
+oc rollout restart deployment/ogx -n ogx
+oc rollout status deployment/ogx -n ogx --timeout=180s
+```
+
+Confirm the shield is registered:
+
+```bash
+curl -s "$OGX_ENDPOINT/shields" | jq
+```
+
+You should see one entry like:
+
+```json
+{
+  "identifier": "code-scanner",
+  "provider_resource_id": "code-scanner",
+  "provider_id": "code-scanner",
+  "type": "shield",
+  "params": {}
+}
+```
+
+## Path B: Llama Guard
+
+The starter distribution already registers `inline::llama-guard` as a safety provider (verify with the `curl /v1/providers` from Path A). The provider doesn't include the model — it expects a `Llama-Guard-*` model registered as one of the configured inference providers, then references it via the shield's `params.model`. So Path B is two steps: serve the Llama Guard model, then register a shield bound to it.
+
+### 1. Serve the Llama Guard model
+
+Mirror [Serve an LLM](serve-an-llm.md) for a second model. You need a second GPU or sufficient VRAM headroom on the existing one. Save as `llama-guard-runtime.yaml`:
+
+```yaml
+apiVersion: serving.kserve.io/v1alpha1
+kind: ServingRuntime
+metadata:
+  name: vllm-llama-guard
+  namespace: model-serving
+spec:
+  supportedModelFormats:
+    - name: pytorch
+      autoSelect: true
+  containers:
+    - name: kserve-container
+      image: quay.io/modh/vllm:latest
+      command: ["python", "-m", "vllm.entrypoints.openai.api_server"]
+      args:
+        - "--model=meta-llama/Llama-Guard-3-8B"
+        - "--port=8080"
+        - "--served-model-name=meta-llama/Llama-Guard-3-8B"
+        - "--max-model-len=4096"
+      env:
+        - name: HF_TOKEN
+          valueFrom:
+            secretKeyRef:
+              name: hf-token
+              key: HF_TOKEN
+      resources:
+        limits:
+          nvidia.com/gpu: "1"
+          memory: 24Gi
+          cpu: "4"
+      ports:
+        - containerPort: 8080
+          protocol: TCP
+---
+apiVersion: serving.kserve.io/v1beta1
+kind: InferenceService
+metadata:
+  name: llama-guard
+  namespace: model-serving
+spec:
+  predictor:
+    model:
+      modelFormat:
+        name: pytorch
+      runtime: vllm-llama-guard
+```
+
+```bash
+oc apply -f llama-guard-runtime.yaml
+oc rollout status -n model-serving deployment/llama-guard-predictor --timeout=1200s
+```
+
+### 2. Register the model and shield in OGX
+
+In OGX, Llama Guard is wired by *adding the model to a vLLM inference provider* and then registering a shield against the `inline::llama-guard` provider with the model id in `params`. Edit `ogx-config`:
+
+```yaml
+providers:
+  inference:
+    - provider_id: vllm
+      provider_type: remote::vllm
+      config:
+        url: ${env.VLLM_URL}
+        # ...existing config unchanged...
+    # NEW: a second vLLM inference provider for the guard model
+    - provider_id: vllm-guard
+      provider_type: remote::vllm
+      config:
+        url: http://llama-guard-predictor.model-serving.svc.cluster.local/v1
+        api_token: fake
+
+models:
+  # ...your existing model entry...
+  - model_id: meta-llama/Llama-Guard-3-8B
+    provider_id: vllm-guard
+    model_type: llm
+
+shields:
+  - shield_id: llama-guard
+    provider_id: llama-guard            # the inline::llama-guard provider
+    params:
+      model: meta-llama/Llama-Guard-3-8B
+```
+
+You can register Path A's `code-scanner` and Path B's `llama-guard` side by side and pick one per agent request via the `guardrails:` array.
+
+Roll the pod and verify as in Path A — `GET /v1/shields` should now return both entries.
+
+## Smoke test the shield
+
+`POST /v1/safety/run-shield` runs a shield against an explicit message and returns whether it fired:
+
+```bash
+curl -s "$OGX_ENDPOINT/safety/run-shield" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "shield_id": "code-scanner",
+    "messages": [{"role": "user", "content": "eval(input())"}]
+  }' | jq
+```
+
+A fired shield returns a `violation` object:
+
+```json
+{
+  "violation": {
+    "violation_level": "error",
+    "user_message": "Sorry, I found security concerns in the code.",
+    "metadata": {
+      "violation_type": "eval-with-expression,insecure-eval-use"
+    }
+  }
+}
+```
+
+A benign message returns `{"violation": null}`. The `metadata.violation_type` field is the comma-separated list of categories that fired — useful for routing different categories to different handlers downstream.
+
+## Export for Module 10
+
+```bash
+export OGX_SHIELD="code-scanner"   # or "llama-guard" if you went with Path B
+```
+
+Module 10 passes this on every Responses request via the `guardrails:` array.
+
+## Next
+
+- [Observability Backends](observability-backends.md) — wire OGX's OTLP exporter
+- Then **[Module 10: Guardrails and Observability](../10-guardrails-and-observability.md)**
+
+## Further reading
+
+- [OGX safety providers](https://ogx-ai.github.io/docs/providers) — full list of the 7 supported providers
+- [Llama Guard 3 model card](https://huggingface.co/meta-llama/Llama-Guard-3-8B)

--- a/docs/guides/install-ogx.md
+++ b/docs/guides/install-ogx.md
@@ -1,0 +1,215 @@
+# Install OGX
+
+[OGX](https://ogx-ai.github.io/) is the rebrand of [LlamaStack](https://github.com/meta-llama/llama-stack) — an open-source AI application server that fronts inference, vector stores, safety shields, MCP tool orchestration, and the OpenAI Responses API behind a single OpenAI-compatible HTTP endpoint.
+
+Modules 1–9 talk to vLLM directly: the agent's `MODEL_ENDPOINT` resolves to a KServe `InferenceService` and the agent runs its own MCP tool loop in `step()`. Module 10 introduces **platform mode**, where the agent talks to OGX instead, and OGX handles MCP tool calls, shield enforcement, and the inference loop server-side.
+
+This guide installs the OGX Kubernetes Operator and creates a minimal `OGXDistribution` that points at your existing vLLM. Subsequent guides layer in shields and observability.
+
+!!! note "When you need this"
+    You only need OGX if you're working through Module 10. Modules 1–9 don't depend on it.
+
+## Prerequisites
+
+- [OpenShift AI installed](install-openshift-ai.md), with vLLM serving a model per [Serve an LLM](serve-an-llm.md)
+- `oc` logged in to the cluster with `cluster-admin` rights (the operator install creates cluster-scoped resources)
+- The `MODEL_ENDPOINT` and `MODEL_NAME` you exported in Serve an LLM
+
+## 1. Install the OGX Operator
+
+The operator is distributed as a single manifest (no OperatorHub package yet — track [ogx-k8s-operator](https://github.com/ogx-ai/ogx-k8s-operator) for OLM-bundled releases).
+
+Pin to a tagged release:
+
+```bash
+OGX_OPERATOR_VERSION=v0.4.0
+oc apply -f https://raw.githubusercontent.com/ogx-ai/ogx-k8s-operator/${OGX_OPERATOR_VERSION}/release/operator.yaml
+```
+
+The operator runs in `ogx-k8s-operator-system`. Wait for it to come up:
+
+```bash
+oc rollout status deployment/ogx-k8s-operator-controller-manager \
+  -n ogx-k8s-operator-system --timeout=180s
+```
+
+Verify the CRDs are registered:
+
+```bash
+oc get crd ogxdistributions.ogx.io
+```
+
+## 2. Create a namespace for OGX
+
+```bash
+oc new-project ogx
+```
+
+## 3. Author the OGX `config.yaml`
+
+OGX is configured by a `config.yaml` mounted via ConfigMap. The minimal config for this tutorial registers one inference provider (your existing vLLM) and one telemetry exporter. Shields and MCP connectors are added by subsequent guides.
+
+Save as `ogx-config.yaml`:
+
+```yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: ogx-config
+  namespace: ogx
+data:
+  config.yaml: |
+    version: '2'
+    image_name: tutorial
+
+    apis:
+      - inference
+      - safety
+      - tool_runtime
+      - telemetry
+
+    providers:
+      inference:
+        - provider_id: vllm
+          provider_type: remote::vllm
+          config:
+            url: ${env.VLLM_URL}
+            max_tokens: ${env.VLLM_MAX_TOKENS:=4096}
+            api_token: ${env.VLLM_API_TOKEN:=fake}
+
+      telemetry:
+        - provider_id: otel
+          provider_type: inline::meta-reference
+          config:
+            service_name: ogx
+            sinks: console,otel_trace,otel_metric
+            otel_endpoint: ${env.OTEL_EXPORTER_OTLP_ENDPOINT:=http://otel-collector.observability.svc.cluster.local:4318}
+
+    models:
+      - model_id: ${env.INFERENCE_MODEL}
+        provider_id: vllm
+        model_type: llm
+
+    shields: []
+    tool_groups: []
+```
+
+The `${env.X}` syntax is OGX's runtime substitution — values come from the operator's `containerSpec.env`. Defaults apply when the env var is unset.
+
+Apply it:
+
+```bash
+oc apply -f ogx-config.yaml
+```
+
+## 4. Create the `OGXDistribution`
+
+The Operator turns this CR into a `Deployment`, `Service`, and `PersistentVolumeClaim`. Save as `ogx-distribution.yaml`:
+
+```yaml
+apiVersion: ogx.io/v1alpha1
+kind: OGXDistribution
+metadata:
+  name: ogx
+  namespace: ogx
+spec:
+  replicas: 1
+  server:
+    distribution:
+      image: docker.io/llamastack/distribution-starter:latest
+    containerSpec:
+      port: 8321
+      env:
+        - name: VLLM_URL
+          value: "http://granite-predictor.model-serving.svc.cluster.local/v1"
+        - name: INFERENCE_MODEL
+          value: "ibm-granite/granite-3.3-8b-instruct"
+        - name: VLLM_API_TOKEN
+          value: "fake"
+    userConfig:
+      configMap:
+        name: ogx-config
+    storage:
+      size: "10Gi"
+      mountPath: "/home/lls/.lls"
+```
+
+Two things to swap for your cluster:
+
+- `VLLM_URL` — internal URL of the vLLM `InferenceService` from [Serve an LLM](serve-an-llm.md). The hostname follows `<service>.<namespace>.svc.cluster.local`.
+- `INFERENCE_MODEL` — the served model name vLLM advertises (the same value you set as `MODEL_NAME`).
+
+The `image: docker.io/llamastack/distribution-starter:latest` reference still uses the `llamastack/` namespace; the rebrand to `ogx-ai/` is in flight upstream.
+
+Apply it:
+
+```bash
+oc apply -f ogx-distribution.yaml
+```
+
+The operator creates a `Deployment` named `ogx` and a `Service` exposing port 8321. Wait for it:
+
+```bash
+oc rollout status deployment/ogx -n ogx --timeout=300s
+```
+
+## 5. Expose the endpoint
+
+For agents running in the cluster, the service URL is enough:
+
+```
+http://ogx.ogx.svc.cluster.local:8321/v1
+```
+
+For local testing with `curl` or `pytest`, expose a Route:
+
+```bash
+oc create route edge ogx --service=ogx --port=8321 -n ogx
+OGX_ENDPOINT="https://$(oc get route ogx -n ogx -o jsonpath='{.spec.host}')/v1"
+echo "$OGX_ENDPOINT"
+```
+
+## 6. Smoke test
+
+OGX exposes the OpenAI-compatible API plus its own native APIs under `/v1`. Hit two of each:
+
+```bash
+# OpenAI-compatible — should return your registered vLLM model
+curl -s "$OGX_ENDPOINT/models" | jq
+
+# Native — should return [] until you register shields
+curl -s "$OGX_ENDPOINT/shields" | jq
+```
+
+A round-trip inference call confirms the path through OGX → vLLM:
+
+```bash
+curl -s "$OGX_ENDPOINT/chat/completions" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "model": "ibm-granite/granite-3.3-8b-instruct",
+    "messages": [{"role": "user", "content": "Say hi."}]
+  }' | jq -r '.choices[0].message.content'
+```
+
+If you get a response, OGX is wired to vLLM correctly.
+
+## 7. Export for Module 10
+
+```bash
+export OGX_ENDPOINT="$OGX_ENDPOINT"
+```
+
+Module 10 reads this as the agent's `MODEL_ENDPOINT` (the agent talks to OGX instead of vLLM directly).
+
+## Next
+
+- [Configure Safety Shields](configure-shields.md) — register shields server-side so platform mode can enforce them
+- [Observability Backends](observability-backends.md) — wire OGX's OTLP exporter to a trace receiver
+- Then **[Module 10: Guardrails and Observability](../10-guardrails-and-observability.md)**
+
+## Further reading
+
+- [OGX architecture](https://ogx-ai.github.io/docs/concepts/architecture)
+- [OGX Kubernetes deployment](https://ogx-ai.github.io/docs/deploying/kubernetes_deployment)
+- [LlamaStack → OGX rebrand](https://ogx-ai.github.io/blog/from-llama-stack-to-ogx)

--- a/docs/guides/observability-backends.md
+++ b/docs/guides/observability-backends.md
@@ -1,0 +1,184 @@
+# Observability Backends
+
+OGX exports traces and metrics in standard OpenTelemetry Protocol (OTLP) format — anything that speaks OTLP can receive them. This guide sets up a receiver so Module 10's Jaeger screenshot moment actually has a UI to point at.
+
+This guide covers two paths:
+
+- **Path A — Jaeger all-in-one**. A single Deployment with a built-in OTLP receiver and trace UI. Right for the tutorial.
+- **Path B — your cluster's existing observability stack**. Right when you've already got Tempo / a managed OpenTelemetry Collector / a corporate observability platform.
+
+## Path A: Jaeger all-in-one
+
+Jaeger's all-in-one image bundles an OTLP receiver, an in-memory trace store, and the Jaeger UI in a single container. Perfect for tutorials and dev clusters; not for production.
+
+### 1. Create a namespace
+
+```bash
+oc new-project observability
+```
+
+### 2. Deploy Jaeger
+
+Save as `jaeger.yaml`:
+
+```yaml
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: jaeger
+  namespace: observability
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: jaeger
+  template:
+    metadata:
+      labels:
+        app: jaeger
+    spec:
+      containers:
+        - name: jaeger
+          image: jaegertracing/all-in-one:1.62
+          env:
+            - name: COLLECTOR_OTLP_ENABLED
+              value: "true"
+          ports:
+            - name: ui
+              containerPort: 16686
+            - name: otlp-grpc
+              containerPort: 4317
+            - name: otlp-http
+              containerPort: 4318
+          resources:
+            requests:
+              cpu: 100m
+              memory: 256Mi
+            limits:
+              cpu: 500m
+              memory: 1Gi
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: jaeger
+  namespace: observability
+spec:
+  selector:
+    app: jaeger
+  ports:
+    - name: ui
+      port: 16686
+      targetPort: 16686
+    - name: otlp-grpc
+      port: 4317
+      targetPort: 4317
+    - name: otlp-http
+      port: 4318
+      targetPort: 4318
+---
+apiVersion: route.openshift.io/v1
+kind: Route
+metadata:
+  name: jaeger-ui
+  namespace: observability
+spec:
+  to:
+    kind: Service
+    name: jaeger
+  port:
+    targetPort: ui
+  tls:
+    termination: edge
+    insecureEdgeTerminationPolicy: Redirect
+```
+
+```bash
+oc apply -f jaeger.yaml
+oc rollout status deployment/jaeger -n observability --timeout=120s
+```
+
+### 3. Get the UI URL
+
+```bash
+JAEGER_UI="https://$(oc get route jaeger-ui -n observability -o jsonpath='{.spec.host}')"
+echo "$JAEGER_UI"
+```
+
+Open it in a browser. You should see the Jaeger UI with no services listed yet — that's expected; nothing has emitted traces.
+
+### 4. Point OGX at the OTLP endpoint
+
+OGX is in a different namespace, so use the cluster-internal DNS name. The OTLP HTTP endpoint is what OGX's `telemetry` provider expects.
+
+Edit the `OGXDistribution` from [Install OGX](install-ogx.md):
+
+```bash
+oc edit ogxdistribution ogx -n ogx
+```
+
+Add or update the `OTEL_EXPORTER_OTLP_ENDPOINT` env var under `spec.server.containerSpec.env`:
+
+```yaml
+spec:
+  server:
+    containerSpec:
+      env:
+        # ...existing entries...
+        - name: OTEL_EXPORTER_OTLP_ENDPOINT
+          value: "http://jaeger.observability.svc.cluster.local:4318"
+```
+
+The Operator rolls the pod automatically. Wait for it:
+
+```bash
+oc rollout status deployment/ogx -n ogx --timeout=180s
+```
+
+### 5. Verify traces flow
+
+Hit OGX's `/v1/chat/completions` to generate a span:
+
+```bash
+curl -s "$OGX_ENDPOINT/chat/completions" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "model": "ibm-granite/granite-3.3-8b-instruct",
+    "messages": [{"role": "user", "content": "Say hi."}]
+  }' > /dev/null
+```
+
+Refresh the Jaeger UI. The **Service** dropdown should now include `ogx`. Pick it, click **Find Traces**, and you'll see a trace per request with spans for inference and any tool calls OGX orchestrated.
+
+### 6. Export for Module 10
+
+```bash
+export JAEGER_UI="$JAEGER_UI"
+```
+
+Module 10 references this URL when telling you to go look at a trace.
+
+## Path B: existing observability stack
+
+If your cluster already has an observability stack — Red Hat OpenShift distributed tracing (Tempo Operator), a managed OpenTelemetry Collector, Datadog Agent with OTLP receiver, etc. — point OGX at its OTLP endpoint instead of Jaeger.
+
+You need two things from your platform team:
+
+| Item | Format | Notes |
+|------|--------|-------|
+| OTLP endpoint URL | `http://collector.<ns>.svc.cluster.local:4318` | HTTP receiver port |
+| Trace UI URL | varies | Tempo, Grafana Tempo datasource, Datadog APM, etc. |
+
+Set `OTEL_EXPORTER_OTLP_ENDPOINT` on the `OGXDistribution` to the collector URL. The trace UI is whatever your platform team gives you — Module 10's "go find your trace" step works the same whether you're looking at Jaeger or Tempo.
+
+If you're running OpenShift's [distributed tracing platform (Tempo)](https://docs.redhat.com/en/documentation/openshift_container_platform/4.20/html/distributed_tracing/distributed-tracing-platform-tempo), the OTLP receiver is part of the `TempoStack` CR (look for `spec.template.distributor`).
+
+## Next
+
+**[Module 10: Guardrails and Observability](../10-guardrails-and-observability.md)**.
+
+## Further reading
+
+- [Jaeger getting started](https://www.jaegertracing.io/docs/latest/getting-started/)
+- [OTLP specification](https://opentelemetry.io/docs/specs/otlp/)
+- [OGX telemetry](https://ogx-ai.github.io/docs/building_applications/telemetry)

--- a/docs/index.md
+++ b/docs/index.md
@@ -59,6 +59,8 @@ tools, and registry access — is its own module:
 | [7. Extend with AI](07-extend-with-ai.md) | Use AI-assisted slash commands to add capabilities |
 | [8. Production Hardening](08-secrets-and-production.md) | Secrets, FIPS, scaling, observability (metrics, traces, sessions, user feedback) |
 | [9. File Uploads](09-file-uploads.md) | Drag-drop uploads, Docling parsing, MIME validation, ClamAV scanning |
+| [10. Platform Mode and Guardrails](10-guardrails-and-observability.md) | Graduate tool orchestration, shields, and tracing to OGX server-side. Requires fipsagents 0.21+ |
+| [11. Scaling with llm-d](11-scaling-with-llm-d.md) | Conceptual: disaggregated prefill/decode + KV-cache routing behind OGX |
 
 ## Reference
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -46,12 +46,17 @@ nav:
     - "7. Extend with AI": 07-extend-with-ai.md
     - "8. Production Hardening": 08-secrets-and-production.md
     - "9. File Uploads": 09-file-uploads.md
+    - "10. Platform Mode and Guardrails": 10-guardrails-and-observability.md
+    - "11. Scaling with llm-d": 11-scaling-with-llm-d.md
   - Setup Guides:
     - "Choosing a Cluster": guides/cluster-options.md
     - "Install OpenShift AI": guides/install-openshift-ai.md
     - "Serve an LLM": guides/serve-an-llm.md
     - "Install CLI Tools": guides/install-cli-tools.md
     - "Registry Setup": guides/registry-setup.md
+    - "Install OGX": guides/install-ogx.md
+    - "Configure Safety Shields": guides/configure-shields.md
+    - "Observability Backends": guides/observability-backends.md
   - Reference:
     - "agent.yaml": reference/agent-yaml.md
     - "Helm Chart": reference/helm-chart.md


### PR DESCRIPTION
## Summary

Two bodies of work merged into a single PR because they grew together during an end-to-end test of the tutorial:

1. **New content** — three setup guides (install-ogx, configure-shields, observability-backends), Module 10 (platform mode against OGX with guardrails and tracing), and Module 11 (conceptual chapter on llm-d). Adds the "graduate concerns to the platform" arc the tutorial was missing past file uploads.
2. **e2e drift fixes** — corrections from a full e2e run against the latest fips-agents/* template versions.

## New content

- `docs/guides/install-ogx.md` — install the OGX Operator and minimal `OGXDistribution` pointing at an existing vLLM
- `docs/guides/configure-shields.md` — Path A built-in `code-scanner`, Path B Llama Guard via second vLLM
- `docs/guides/observability-backends.md` — Jaeger all-in-one for tutorial use; pointer to OpenShift distributed tracing for prod
- `docs/10-guardrails-and-observability.md` — switch `step()` to `call_model_responses`, expand the `platform:` block, trigger a guardrail, find the trace, contrast moderation vs guardrails
- `docs/11-scaling-with-llm-d.md` — conceptual chapter (no code); where llm-d slots in behind OGX, when to reach for it

## Drift fixes

The e2e run surfaced drift between the tutorial text and current template behavior. Each fix is small and targeted; details on each in the commit message.

| Module | Fix |
|---|---|
| 1 | `src/agent.py` snippet, `prompts/system.md` example, `/v1/agent-info` JSON, add `platform:` to agent.yaml tour, document MemoryHub log line |
| 4 | Drop the obsolete "delete tools/web_search.py" step; rephrase "Research Assistant prompt" |
| 5 | `$CTX` placeholder instead of hardcoded context; use new `make build-openshift` for UI; add `oc rollout restart` until gateway-template#37 / ui-template#26 land |
| 6 | Add "Build the sandbox image" section pointing at fips-agents/code-sandbox; pin values.yaml image repo to in-cluster IS |
| 10 | Rephrase from "add" to "expand" the platform block; warn that MODEL_NAME must switch to the OGX-prefixed form; route-timeout tip |

## Test plan

- [x] `mkdocs build --strict` passes
- [x] All new pages render under their nav entries
- [x] All cross-links between modules and guides resolve
- [ ] (Out-of-band) re-run the e2e against the new template versions once the two cross-referenced template PRs (gateway-template#37, ui-template#26) merge — the `oc rollout restart` workaround can come back out then.

## Cross-references

- agent-template#154 / agent-template#157 — the framework PR that landed platform mode (the foundation for Module 10)
- gateway-template#37, ui-template#26 — the `checksum/config` annotation gap; Module 5 currently documents an `oc rollout restart` workaround that becomes redundant once both land
- fips-agents-cli#40, gateway-template#35, ui-template#25, agent-template#158 — the four bugs filed during the prior e2e run; the rerun confirmed all are fixed and the new template/CLI versions are what this PR's drift fixes target

🤖 Generated with [Claude Code](https://claude.com/claude-code)