### PR TITLE
Tutorial walkthrough fixes and MaaS inline setup

### DIFF
--- a/calculus-agent/pyproject.toml
+++ b/calculus-agent/pyproject.toml
@@ -17,7 +17,7 @@ feedback = [
 ]
 files = [
     # Pulls in docling (text extraction) + python-magic (content-based
-    # MIME sniffing). Adds ~500MB to the container image because of
+    # MIME sniffing). Adds ~5 GB to the container image because of
     # docling's torch/transformers — leave opt-in unless the agent
     # actively ingests files.
     "fipsagents[files]",

--- a/docs/00-prerequisites.md
+++ b/docs/00-prerequisites.md
@@ -44,7 +44,15 @@ enabled for model serving. RHOAI 3.x requires OpenShift 4.20+.
 
 → See [Install OpenShift AI](guides/install-openshift-ai.md).
 
-### 3. An LLM (RedHatAI/gpt-oss-20b)
+### 3. A GPU node (Path A only)
+
+On-cluster model serving requires at least one GPU-enabled worker node. If
+your cluster doesn't have one yet, provision it before installing OpenShift
+AI or deploying the model.
+
+→ See [GPU Node Setup](guides/gpu-node-setup.md).
+
+### 4. An LLM (RedHatAI/gpt-oss-20b)
 
 The tutorial uses **`RedHatAI/gpt-oss-20b`** served via vLLM. You need:
 
@@ -57,7 +65,7 @@ The tutorial uses **`RedHatAI/gpt-oss-20b`** served via vLLM. You need:
 → See [Serve an LLM](guides/serve-an-llm.md). The Path B fallback is in the
 same guide.
 
-### 4. CLI tools
+### 5. CLI tools
 
 - `oc` (OpenShift client)
 - `helm` 3.x
@@ -67,7 +75,7 @@ same guide.
 
 → See [Install CLI Tools](guides/install-cli-tools.md).
 
-### 5. A container registry you can push to
+### 6. A container registry you can push to
 
 Modules 2, 3, and 6 build and push container images. Quay.io (free public
 namespaces) works for the tutorial; the OpenShift internal registry works

--- a/docs/01-scaffold-agent.md
+++ b/docs/01-scaffold-agent.md
@@ -28,9 +28,9 @@ cd calculus-agent && ls
 ```
 .claude/        AGENTS.md       CLAUDE.md       Containerfile
 Makefile        README.md       agent.yaml      chart/
-deploy.sh       evals/          prompts/        pyproject.toml
-redeploy.sh     rules/          skills/         src/
-tests/          tools/
+deploy.sh       evals/          identity.md     personality.md
+prompts/        pyproject.toml  redeploy.sh     rules/
+skills/         src/            tests/          tools/
 ```
 
 ## Project structure
@@ -44,6 +44,8 @@ tests/          tools/
 | `skills/` | Progressive-disclosure capabilities (agentskills.io spec) |
 | `rules/` | Behavioral constraints, one Markdown file per rule |
 | `chart/` | Helm chart for deploying to OpenShift |
+| `identity.md` | Agent identity definition (name, role, personality traits) |
+| `personality.md` | Agent personality and communication style |
 | `evals/` | Test scenarios and eval runner |
 | `Containerfile` | Multi-stage build using Red Hat UBI base images |
 | `Makefile` | Development and deployment commands |
@@ -71,14 +73,17 @@ We'll change these to match our calculus agent in Module 2.
 
 ```yaml
 model:
+  provider: ${MODEL_PROVIDER:-openai}
   endpoint: ${MODEL_ENDPOINT:-http://llamastack:8321/v1}
   name: ${MODEL_NAME:-meta-llama/Llama-3.3-70B-Instruct}
   temperature: 0.7
   max_tokens: 4096
 ```
 
-This points at any OpenAI-compatible API -- vLLM, LlamaStack, llm-d, or even
-OpenAI itself.
+The `provider` field selects the LLM backend. The default (`openai`) works with
+any OpenAI-compatible API -- vLLM, LlamaStack, llm-d, or even OpenAI itself.
+Set it to `anthropic`, `bedrock`, or `azure` to route through an adapter
+sidecar instead.
 
 !!! tip "Environment variable substitution"
     `${MODEL_ENDPOINT:-http://llamastack:8321/v1}` means: use the
@@ -135,6 +140,32 @@ controls which tool plane a tool belongs to if it doesn't declare one
 explicitly (more on planes below). The server section configures the HTTP
 binding -- the agent exposes an OpenAI-compatible `/v1/chat/completions`
 endpoint that the gateway and UI communicate through.
+
+### Prompt assembly (layered mode)
+
+The scaffold includes a `prompt_assembly` section that replaces the flat
+system-prompt concatenation with named layers:
+
+```yaml
+prompt_assembly:
+  identity:
+    source: identity.md
+    enabled: true
+  personality:
+    source: personality.md
+    enabled: false
+  governance_enabled: true
+  capabilities_enabled: true
+```
+
+This is what `identity.md` and `personality.md` in the project root are for.
+When `prompt_assembly` is present, `build_system_prompt()` assembles the system
+message from four layers in precedence order: identity (who the agent IS),
+personality (how it behaves), governance (rules/), and capabilities (skills/).
+Identity is on by default; personality is off until you enable it.
+
+When `prompt_assembly` is absent, the legacy flat concatenation (system prompt
++ rules + skills) is used instead. We'll customize `identity.md` in Module 2.
 
 ## Understanding src/agent.py
 
@@ -323,16 +354,27 @@ curl localhost:8080/v1/agent-info | python -m json.tool
         "max_tokens": 4096
     },
     "system_prompt": "You are a helpful assistant.\n\n## Instructions\n...",
-    "tools": []
+    "tools": [
+        {
+            "name": "ask_user",
+            "description": "Ask the user a clarifying question"
+        },
+        {
+            "name": "spawn_agent",
+            "description": "Spawn a sub-agent to handle a delegated task"
+        }
+    ]
 }
 ```
 
 The `model.name` value reflects whatever you configured in `agent.yaml`; the
 scaffold default is shown here.
 
-The `tools` array is a list of objects (`{name, description, parameters}`)
-when tools are registered, and `system_prompt` reflects the rendered prompt
-text after rule and skill injection.
+The `tools` array lists every tool registered with `llm_only` or `both`
+visibility. The two shown above are **stock tools** that BaseAgent always
+registers -- `ask_user` for interactive clarification and `spawn_agent` for
+multi-agent delegation. `system_prompt` reflects the rendered prompt text
+after rule and skill injection.
 
 !!! note "MemoryHub log line"
     On first start you'll see `MemoryHub config at .memoryhub.yaml has no

--- a/docs/02-configure-and-deploy.md
+++ b/docs/02-configure-and-deploy.md
@@ -97,15 +97,7 @@ reachable inside the cluster via its Service.
 256Mi memory) are reasonable because the agent is I/O-bound: it spends most
 of its time waiting for LLM responses over the network.
 
-## Build the container image
-
-You need a container image before you can deploy. There are two approaches.
-
-### Option A: OpenShift BuildConfig (recommended)
-
-A BuildConfig builds your image directly in the cluster's internal registry.
-No need to push images to an external registry, and the build runs on x86_64
-regardless of your laptop's architecture.
+## Deploy to OpenShift
 
 First, create the namespace where the agent will be deployed:
 
@@ -116,34 +108,73 @@ oc new-project calculus-agent --context="$CTX"
 This creates the `calculus-agent` namespace and sets up the necessary
 service accounts for builds and deployments.
 
-```bash
-# Create a binary BuildConfig that accepts source uploads
-oc new-build --binary --name=calculus-agent --strategy=docker -n calculus-agent --context="$CTX"
+Deploying the agent requires three operations: build the container image
+in the cluster, resolve the image registry path, and install the Helm
+chart. MCP servers (Module 3) can use `fips-agents deploy` for all of
+this in one command, but agent projects currently require the manual
+steps below.
 
-# Tell it to use Containerfile instead of Dockerfile
+### Build the container image
+
+Create a binary BuildConfig that accepts source uploads, then start
+the build:
+
+```bash
+# Create the BuildConfig
+oc new-build --binary --name=calculus-agent --strategy=docker \
+  -n calculus-agent --context="$CTX"
+
+# Point it at the Containerfile
 oc patch bc/calculus-agent --type=json \
   -p '[{"op":"replace","path":"/spec/strategy/dockerStrategy/dockerfilePath","value":"Containerfile"}]' \
   -n calculus-agent --context="$CTX"
 
-# Upload your source and start the build
-oc start-build calculus-agent --from-dir=. --follow -n calculus-agent --context="$CTX"
+# Upload source and build
+oc start-build calculus-agent --from-dir=. --follow \
+  -n calculus-agent --context="$CTX"
 ```
 
-!!! info "What is a BuildConfig?"
-    A BuildConfig is an OpenShift resource that tells the platform how to build
-    a container image. With `--binary`, it accepts source code uploaded from
-    your local machine and builds the image server-side. The resulting image is
-    pushed to the cluster's internal registry automatically -- no external
-    registry credentials needed.
+The build runs server-side on x86_64 — no architecture mismatches
+regardless of your laptop.
 
-The `--follow` flag streams build logs to your terminal. When the build
-completes you will see a line like `Push successful` followed by the internal
-image reference.
+### Deploy with Helm
 
-### Option B: Local build + push
+Resolve the ImageStream to get the internal registry path, then install
+the chart:
 
-If you prefer to build locally (or need to push to an external registry like
-Quay), use the Makefile target:
+```bash
+IMAGE=$(oc get is calculus-agent -n calculus-agent --context="$CTX" \
+  -o jsonpath='{.status.dockerImageRepository}')
+
+helm install calculus-agent chart/ \
+  --set image.repository=$IMAGE \
+  --set image.tag=latest \
+  --set image.pullPolicy=Always \
+  --set config.MODEL_ENDPOINT=$MODEL_ENDPOINT \
+  --set config.MODEL_NAME=$MODEL_NAME \
+  --set config.OPENAI_API_KEY=not-required \
+  --set route.enabled=true \
+  -n calculus-agent --kube-context="$CTX"
+```
+
+Replace `$MODEL_ENDPOINT` and `$MODEL_NAME` with the values from the
+"Set your model endpoint" section above.
+
+The `--set config.*` flags inject environment variables into the
+ConfigMap that gets mounted in the pod. These override the
+`${VAR:-default}` placeholders in `agent.yaml` at runtime:
+
+- **`config.MODEL_ENDPOINT`** — the `/v1` URL of your vLLM or
+  LlamaStack inference endpoint.
+- **`config.MODEL_NAME`** — the model identifier your endpoint expects.
+- **`config.OPENAI_API_KEY`** — satisfies the SDK requirement. Set to a
+  real key only if your endpoint requires authentication.
+
+The result is a Deployment, Service, ConfigMap, and Route.
+
+### Alternative: Local build + push
+
+If you need to push to an external registry (e.g. Quay), build locally instead:
 
 ```bash
 make build IMAGE_NAME=calculus-agent IMAGE_TAG=v1
@@ -155,61 +186,6 @@ podman push calculus-agent:v1 quay.io/your-org/calculus-agent:v1
     with raw `podman build` on an Apple Silicon Mac, you must include that flag
     yourself or the image will be ARM64, which will not run on x86_64 OpenShift
     nodes.
-
-## Deploy with Helm
-
-!!! info "Deploy mechanisms in this tutorial"
-    Different components use different deploy mechanisms:
-
-    - **Agent** (this module): `helm install` / `helm upgrade` via the chart in
-      `chart/`. The chart produces a Deployment, Service, ConfigMap, and Route.
-    - **MCP server** (Module 3): `./deploy.sh <namespace>`, which applies
-      `openshift.yaml` (BuildConfig + Deployment + Service + Route).
-    - **Gateway and UI** (Module 5): `make build-openshift PROJECT=<namespace>`
-      to build, then `make deploy PROJECT=<namespace>` to deploy.
-
-    The `Makefile` wraps these: `make deploy PROJECT=<namespace>` calls the
-    right tool for each project type.
-
-With the image built, deploy the agent:
-
-```bash
-# Get the internal registry path for the image we just built
-IMAGE=$(oc get is calculus-agent -n calculus-agent --context="$CTX" -o jsonpath='{.status.dockerImageRepository}')
-
-# Deploy the chart
-helm install calculus-agent chart/ \
-  --set image.repository=$IMAGE \
-  --set image.tag=latest \
-  --set image.pullPolicy=Always \
-  --set config.MODEL_ENDPOINT=http://vllm-predictor.model-ns.svc.cluster.local/v1 \
-  --set config.MODEL_NAME=/mnt/models \
-  --set config.OPENAI_API_KEY=not-required \
-  --set route.enabled=true \
-  -n calculus-agent --kube-context="$CTX"
-```
-
-Here is what each `--set` does:
-
-- **`image.repository`** -- points at the image stream in the internal
-  registry. The `oc get is` command retrieves the full path.
-- **`image.tag`** -- `latest` tracks the most recent build. Pin to a specific
-  tag for production.
-- **`image.pullPolicy=Always`** -- forces Kubernetes to pull the image on every
-  pod restart, so you always get the latest build.
-- **`config.MODEL_ENDPOINT`** -- the `/v1` URL of your vLLM or LlamaStack
-  inference endpoint.
-- **`config.MODEL_NAME`** -- the model identifier your endpoint expects.
-- **`config.OPENAI_API_KEY`** -- satisfies the SDK requirement. Set to a real
-  key only if your endpoint requires authentication.
-- **`route.enabled=true`** -- creates an OpenShift Route so you can reach the
-  agent from outside the cluster.
-
-!!! info "What is an ImageStream?"
-    An ImageStream is an OpenShift abstraction that tracks container images in
-    the internal registry. When you build with a BuildConfig, the output image
-    is tagged in an ImageStream. `oc get is` shows you the registry path that
-    Kubernetes needs to pull the image.
 
 ## Verify the deployment
 
@@ -257,9 +233,9 @@ curl -sk "https://$ROUTE/v1/traces" | python -m json.tool
 These are the most common issues and how to fix them.
 
 **ImagePullBackOff** -- Kubernetes cannot pull the container image. The image
-repository path is usually wrong. Run `oc get is -n calculus-agent --context="$CTX"` to find
-the correct internal registry path, then `helm upgrade` with the corrected
-`image.repository` value.
+repository path is usually wrong. Re-run `fips-agents deploy` (it resolves the
+ImageStream automatically) or check the path manually with
+`oc get is -n calculus-agent --context="$CTX"` and `helm upgrade`.
 
 **CrashLoopBackOff** -- the container starts and immediately crashes. Check
 logs with `oc logs deployment/calculus-agent -n calculus-agent --context="$CTX"`. Common causes:
@@ -293,7 +269,9 @@ version, restart the deployment to pick it up:
 ## Redeploying after changes
 
 The development cycle for deployed agents is: edit code, rebuild the image,
-restart the deployment. Here is the sequence:
+restart the deployment. You can re-run `fips-agents deploy` for a full
+rebuild-and-deploy, or use the manual commands for faster iteration when you
+only need to rebuild:
 
 ```bash
 # 1. Rebuild the image in the cluster
@@ -314,9 +292,9 @@ make redeploy PROJECT=calculus-agent
 
 !!! tip "Updating configuration without rebuilding"
     If you only need to change environment variables (model endpoint, log level,
-    etc.), you do not need to rebuild the image. Run `helm upgrade` with the new
-    `--set config.*` values. The ConfigMap checksum annotation in the Deployment
-    template automatically triggers a rolling restart when the ConfigMap changes.
+    etc.), you do not need to rebuild the image. Re-run `fips-agents deploy`
+    with updated `--set config.*` values -- it skips the build when the source
+    hasn't changed. Or use `helm upgrade` directly:
 
     ```bash
     helm upgrade calculus-agent chart/ \
@@ -345,7 +323,21 @@ server:
     enabled: true
 ```
 
-To enable these in a deployed agent, pass the corresponding Helm overrides:
+To enable these in a deployed agent, re-run `fips-agents deploy` with the
+extra config flags:
+
+```bash
+fips-agents deploy --context="$CTX" -n calculus-agent \
+  --set config.MODEL_ENDPOINT=$MODEL_ENDPOINT \
+  --set config.MODEL_NAME=$MODEL_NAME \
+  --set config.OPENAI_API_KEY=not-required \
+  --set config.STORAGE_BACKEND=sqlite \
+  --set config.SESSIONS_ENABLED=true \
+  --set config.TRACES_ENABLED=true \
+  --set config.METRICS_ENABLED=true
+```
+
+Or apply just the observability flags with `helm upgrade --reuse-values`:
 
 ```bash
 helm upgrade calculus-agent chart/ \

--- a/docs/03-build-mcp-server.md
+++ b/docs/03-build-mcp-server.md
@@ -23,7 +23,6 @@ The generated project follows a convention-over-configuration pattern:
 | `src/prompts/` | Prompt implementations (empty for this project) |
 | `Containerfile` | Red Hat UBI build for OpenShift |
 | `openshift.yaml` | BuildConfig, Deployment, Service, Route |
-| `deploy.sh` | One-command deploy script |
 
 ### How auto-discovery works
 
@@ -327,16 +326,25 @@ async def test_caret_raises():
 
 ## Deploy to OpenShift
 
-The project includes `openshift.yaml` (BuildConfig, Deployment, Service, Route)
-and a `deploy.sh` script that applies them, uploads source, builds the
-container, and waits for rollout:
+The project includes `openshift.yaml` (BuildConfig, Deployment, Service,
+Route). Deploy with a single command:
+
+```bash
+fips-agents deploy --context="$CTX" -n calculus-mcp
+```
+
+This applies `openshift.yaml`, uploads your source, builds the container in
+the cluster, and waits for the rollout to complete.
+
+Alternatively, use the bundled shell script:
 
 ```bash
 ./deploy.sh calculus-mcp
 ```
 
-The Containerfile uses `registry.redhat.io/ubi9/python-311:latest` and sets the
-HTTP transport environment for port 8080.
+Both commands do the same thing. The Containerfile uses
+`registry.redhat.io/ubi9/python-311:latest` and sets the HTTP transport
+environment for port 8080.
 
 !!! warning "File permissions"
     The Containerfile includes `RUN find ./src -name "*.py" -exec chmod 644 {} \;`

--- a/docs/04-wire-mcp-to-agent.md
+++ b/docs/04-wire-mcp-to-agent.md
@@ -164,7 +164,7 @@ results, and re-calls the model until no more tool calls remain.
 
 ## Rebuild and redeploy
 
-With the three files updated, rebuild the container and push a new deployment:
+With the three files updated, rebuild and redeploy:
 
 ```bash
 # Rebuild the image in the cluster
@@ -175,12 +175,6 @@ oc rollout restart deployment/calculus-agent --context="$CTX" -n calculus-agent
 
 # Wait for the new pod to become ready
 oc rollout status deployment/calculus-agent --context="$CTX" -n calculus-agent
-```
-
-Or use the Makefile shortcut:
-
-```bash
-make redeploy PROJECT=calculus-agent
 ```
 
 !!! warning "MCP server must be running"

--- a/docs/05-gateway-and-ui.md
+++ b/docs/05-gateway-and-ui.md
@@ -189,29 +189,25 @@ injected into the frontend JavaScript.
     export CTX=$(oc config current-context)
     ```
 
-Build and deploy the gateway to your namespace:
+Build and deploy the gateway to your namespace. `BACKEND_URL` must be set
+during the initial install -- the default points at a placeholder service that
+doesn't exist, so the readiness probe will fail and the deploy will hang if
+you skip it:
 
 ```bash
 cd calculus-gateway
 make build-openshift PROJECT=calculus-agent
-make deploy PROJECT=calculus-agent
+
+helm upgrade --install calculus-gateway chart/ \
+  --set config.BACKEND_URL=http://calculus-agent:8080 \
+  -n calculus-agent --kube-context="$CTX"
+
+oc rollout status deployment/calculus-gateway -n calculus-agent --context="$CTX"
 ```
 
 `make build-openshift` creates a BuildConfig (if one doesn't already exist),
-uploads the source, and builds the image in the cluster. `make deploy` runs
-`helm upgrade --install` with the chart. You need to set `BACKEND_URL` to the
-agent's in-cluster service URL:
-
-```bash
-helm upgrade calculus-gateway chart/ \
-  --set config.BACKEND_URL=http://calculus-agent:8080 \
-  --reuse-values \
-  -n calculus-agent --kube-context="$CTX"
-
-# Roll the pod so it picks up the new ConfigMap
-oc rollout restart deployment/calculus-gateway -n calculus-agent --context="$CTX"
-oc rollout status deployment/calculus-gateway -n calculus-agent --context="$CTX"
-```
+uploads the source, and builds the image in the cluster. The `helm upgrade
+--install` deploys the chart with the correct backend URL from the start.
 
 !!! note "In-cluster service DNS"
     `http://calculus-agent:8080` uses Kubernetes short-name DNS. This works
@@ -242,19 +238,11 @@ gateway pod --> agent service --> agent pod.
 ```bash
 cd calculus-ui
 make build-openshift PROJECT=calculus-agent
-make deploy PROJECT=calculus-agent
-```
 
-Then set `API_URL` to point at the gateway's **in-cluster** service URL:
-
-```bash
-helm upgrade calculus-ui chart/ \
+helm upgrade --install calculus-ui chart/ \
   --set config.API_URL=http://calculus-gateway:8080 \
-  --reuse-values \
   -n calculus-agent --kube-context="$CTX"
 
-# Roll the pod so it picks up the new ConfigMap
-oc rollout restart deployment/calculus-ui -n calculus-agent --context="$CTX"
 oc rollout status deployment/calculus-ui -n calculus-agent --context="$CTX"
 ```
 

--- a/docs/05-gateway-and-ui.md
+++ b/docs/05-gateway-and-ui.md
@@ -198,7 +198,12 @@ you skip it:
 cd calculus-gateway
 make build-openshift PROJECT=calculus-agent
 
+# Resolve the image path from the ImageStream the build created
+GW_IMAGE=$(oc get is calculus-gateway --context="$CTX" -n calculus-agent \
+  -o jsonpath='{.status.dockerImageRepository}')
+
 helm upgrade --install calculus-gateway chart/ \
+  --set image.repository=$GW_IMAGE \
   --set config.BACKEND_URL=http://calculus-agent:8080 \
   -n calculus-agent --kube-context="$CTX"
 
@@ -206,8 +211,11 @@ oc rollout status deployment/calculus-gateway -n calculus-agent --context="$CTX"
 ```
 
 `make build-openshift` creates a BuildConfig (if one doesn't already exist),
-uploads the source, and builds the image in the cluster. The `helm upgrade
---install` deploys the chart with the correct backend URL from the start.
+uploads the source, and builds the image in the cluster. The `oc get is`
+command reads the internal registry path from the resulting ImageStream --
+without `--set image.repository`, the chart defaults to a short name that
+the cluster cannot pull. The `helm upgrade --install` deploys the chart with
+the correct image and backend URL from the start.
 
 !!! note "In-cluster service DNS"
     `http://calculus-agent:8080` uses Kubernetes short-name DNS. This works
@@ -239,7 +247,12 @@ gateway pod --> agent service --> agent pod.
 cd calculus-ui
 make build-openshift PROJECT=calculus-agent
 
+# Resolve the image path from the ImageStream the build created
+UI_IMAGE=$(oc get is calculus-ui --context="$CTX" -n calculus-agent \
+  -o jsonpath='{.status.dockerImageRepository}')
+
 helm upgrade --install calculus-ui chart/ \
+  --set image.repository=$UI_IMAGE \
   --set config.API_URL=http://calculus-gateway:8080 \
   -n calculus-agent --kube-context="$CTX"
 

--- a/docs/06-code-sandbox.md
+++ b/docs/06-code-sandbox.md
@@ -104,11 +104,16 @@ When `sandbox.enabled` is `true`, the Helm chart does two things:
 The sidecar shares the pod's network namespace, so the agent reaches it at
 `localhost:8000` with no Service or Route required.
 
-Deploy the updated chart:
+Deploy the updated chart, pointing at the ImageStream the build created:
 
 ```bash
+# Resolve the sandbox image path from the ImageStream
+SANDBOX_IMAGE=$(oc get is code-sandbox --context="$CTX" -n calculus-agent \
+  -o jsonpath='{.status.dockerImageRepository}')
+
 helm upgrade calculus-agent chart/ \
   --set sandbox.enabled=true \
+  --set sandbox.image.repository=$SANDBOX_IMAGE \
   --reuse-values \
   -n calculus-agent --kube-context="$CTX"
 ```

--- a/docs/06-code-sandbox.md
+++ b/docs/06-code-sandbox.md
@@ -235,6 +235,24 @@ oc rollout restart deployment/calculus-agent -n calculus-agent --context="$CTX"
 oc rollout status deployment/calculus-agent -n calculus-agent --context="$CTX"
 ```
 
+### Set the agent route timeout
+
+In Module 5, you set 120-second timeouts on the gateway and UI routes. The
+agent route also needs this -- sandbox code execution adds a tool-call round
+trip on top of the LLM call, and multi-step queries (symbolic result followed
+by numerical evaluation) can easily exceed the default 30-second timeout:
+
+```bash
+oc annotate route calculus-agent \
+  haproxy.router.openshift.io/timeout=120s \
+  --overwrite -n calculus-agent --context="$CTX"
+```
+
+This matters less when traffic flows through the gateway (the gateway's own
+timeout governs that path), but any direct `curl` to the agent route -- like
+the verification commands below -- will hit the 30-second default without this
+annotation.
+
 Verify the agent discovered the new local tool alongside the MCP tools:
 
 ```bash

--- a/docs/07-extend-with-ai.md
+++ b/docs/07-extend-with-ai.md
@@ -147,13 +147,15 @@ scenarios. You can re-run them later with `make eval` from the agent project
 With all eight tools passing tests and exercised for ergonomics, deploy:
 
 ```bash
-./deploy.sh calculus-mcp
+fips-agents deploy --context="$CTX" -n calculus-mcp
 ```
 
-Or using the Makefile:
+You can also use the Makefile wrapper or the standalone deploy script:
 
 ```bash
 make deploy PROJECT=calculus-mcp
+# or
+./deploy.sh calculus-mcp
 ```
 
 The deployment rebuilds the container image and rolls out the new pod. The

--- a/docs/07-extend-with-ai.md
+++ b/docs/07-extend-with-ai.md
@@ -182,10 +182,17 @@ curl -sk "https://$ROUTE/v1/agent-info" | python -m json.tool
     "tools": [
         "integrate", "differentiate", "evaluate_limit",
         "taylor_series", "solve_equation", "solve_ode",
-        "simplify_expression", "evaluate_numeric", "code_executor"
+        "simplify_expression", "evaluate_numeric", "code_executor",
+        "ask_user", "spawn_agent"
     ]
 }
 ```
+
+!!! note "Stock tools in the tool list"
+    `ask_user` and `spawn_agent` are stock tools provided by the BaseAgent
+    framework. They appear in the agent-info response alongside your
+    calculus tools and the code executor. The exact set of stock tools may
+    vary with framework version.
 
 ## Update the system prompt
 

--- a/docs/09-file-uploads.md
+++ b/docs/09-file-uploads.md
@@ -176,37 +176,34 @@ files:
   # bytes_dir defaults to ./files inside the container; mount a PVC there.
 ```
 
-!!! warning "S3-compatible bytes backend is not yet shipped"
-    The agent server keeps bytes on local FS regardless of the metadata
-    backend. An S3-compatible `BytesStore` ABC is on the roadmap. Until
-    it lands, multi-replica deployments need a `ReadWriteMany` PVC or a
-    sticky-session ingress to keep uploads consistent.
+!!! tip "S3-compatible bytes backend"
+    The agent server supports an S3-compatible `BytesStore` backend
+    (`bytes_backend.type: s3` in `agent.yaml`). Use it for multi-replica
+    deployments so pods don't need a shared `ReadWriteMany` PVC.
 
-### MinIO as the bytes target (looking ahead)
+### MinIO as the bytes target
 
-When the S3 backend lands, the recommended setup will be a **MinIO**
-deployment alongside the agent:
+The recommended S3-compatible setup is a **MinIO** deployment alongside
+the agent:
 
 ```bash
-# Future scaffolding (not yet shipped):
 helm install minio bitnami/minio \
   -n calculus-agent \
   --set auth.rootUser=agent --set auth.rootPassword='<from-secret>' \
   --set defaultBuckets=agent-files
 
-# agent.yaml would then point at:
+# agent.yaml — point at the MinIO service:
 files:
-  bytes_backend: s3
-  s3:
-    endpoint: http://minio:9000
-    bucket: agent-files
-    access_key_secret: minio-credentials
+  bytes_backend:
+    type: s3
+    s3:
+      endpoint: http://minio:9000
+      bucket: agent-files
+      access_key_secret: minio-credentials
 ```
 
 MinIO is on-cluster, supports the S3 API, and works with the FIPS-validated
-TLS settings discussed in [Module 8](08-secrets-and-production.md). For now
-treat this as documentation of intent — keep an eye on agent-template#100
-for the real release.
+TLS settings discussed in [Module 8](08-secrets-and-production.md).
 
 ## Security: defense in depth
 

--- a/docs/09-file-uploads.md
+++ b/docs/09-file-uploads.md
@@ -384,7 +384,18 @@ files = ["fipsagents[files]"]
 dev = [
 ```
 
-Then install:
+Update the `Containerfile` so the container image installs the files extra.
+Find the `pip install` line in the builder stage and change it:
+
+```diff
+- && pip install --no-cache-dir .
++ && pip install --no-cache-dir '.[files]'
+```
+
+Without this change, `make build` produces an image without Docling or
+python-magic, and `/v1/files` will fail at runtime with an import error.
+
+Then install locally:
 
 ```bash
 cd calculus-agent
@@ -447,14 +458,25 @@ Once the agent is happy locally, redeploy:
 
 ```bash
 make deploy PROJECT=calculus-agent
-helm upgrade calculus-gateway ../calculus-gateway/chart \
+helm upgrade calculus-gateway calculus-gateway \
   --kube-context="$CTX" -n calculus-agent \
+  --reuse-values \
   --set files.maxBytes=25m \
   --set files.allowedMime="application/pdf,image/*"
-helm upgrade calculus-ui ../calculus-ui/chart \
+helm upgrade calculus-ui calculus-ui \
   --kube-context="$CTX" -n calculus-agent \
+  --reuse-values \
   --set files.maxBytes=25m
 ```
+
+!!! note "Reusing the deployed chart"
+    The gateway and UI were scaffolded in `/tmp` during
+    [Module 5](05-gateway-and-ui.md) and deployed via `helm install`.
+    Here we use `--reuse-values` to keep the existing chart and only
+    override the file-upload settings. If Helm cannot find the release,
+    `cd` to the directory where you originally scaffolded
+    `calculus-gateway` and `calculus-ui` and pass the local chart path
+    instead (e.g., `helm upgrade calculus-gateway ./chart ...`).
 
 Open the UI, drag a PDF onto the chat input, watch the progress chip,
 then ask a question.

--- a/docs/guides/gpu-node-setup.md
+++ b/docs/guides/gpu-node-setup.md
@@ -1,0 +1,360 @@
+# GPU Node Setup
+
+This guide provisions a GPU-enabled worker node on an AWS-based OpenShift
+cluster. The GPU node is required for on-cluster model serving (Path A in
+[Serve an LLM](serve-an-llm.md)) and for the
+[Models as a Service](../supplementary/maas-model-serving.md) supplementary
+module.
+
+The process installs two operators (Node Feature Discovery and NVIDIA GPU
+Operator), creates a GPU-capable MachineSet, and applies the NVIDIA
+ClusterPolicy that configures drivers and device plugins.
+
+!!! info "Prerequisites"
+    - OpenShift 4.20+ on AWS
+    - `cluster-admin` access
+    - `oc` logged in to the cluster
+    - Budget for a GPU instance (~$1.60/hr for `g6e.4xlarge`)
+
+!!! tip "Multi-cluster safety"
+    Every `oc` command in this guide includes `--context="$CTX"` to avoid
+    targeting the wrong cluster. Set it once per shell session:
+
+    ```bash
+    export CTX=$(oc config current-context)
+    ```
+
+## Step 1: Install Node Feature Discovery (NFD)
+
+NFD detects hardware features on each node — including GPUs — and exposes
+them as Kubernetes labels. The NVIDIA GPU Operator depends on these labels,
+so NFD must be installed first.
+
+Create the namespace, then apply the OperatorGroup and Subscription:
+
+```bash
+oc create namespace openshift-nfd --context="$CTX" --dry-run=client -o yaml \
+  | oc apply --context="$CTX" -f -
+```
+
+```yaml
+apiVersion: operators.coreos.com/v1
+kind: OperatorGroup
+metadata:
+  name: openshift-nfd-group
+  namespace: openshift-nfd
+spec:
+  targetNamespaces:
+    - openshift-nfd
+---
+apiVersion: operators.coreos.com/v1alpha1
+kind: Subscription
+metadata:
+  name: nfd
+  namespace: openshift-nfd
+spec:
+  channel: stable
+  installPlanApproval: Automatic
+  name: nfd
+  source: redhat-operators
+  sourceNamespace: openshift-marketplace
+```
+
+```bash
+oc apply --context="$CTX" -f nfd-subscription.yaml
+```
+
+Wait for the operator to install:
+
+```bash
+oc get csv --context="$CTX" -n openshift-nfd -w
+```
+
+Once the CSV phase shows `Succeeded`, create the NFD instance operand.
+This tells the operator to start scanning nodes:
+
+```yaml
+apiVersion: nfd.openshift.io/v1
+kind: NodeFeatureDiscovery
+metadata:
+  name: nfd-instance
+  namespace: openshift-nfd
+spec:
+  workerConfig:
+    configData: |
+      core:
+        sleepInterval: 60s
+```
+
+```bash
+oc apply --context="$CTX" -f nfd-instance.yaml
+```
+
+## Step 2: Install the NVIDIA GPU Operator
+
+Create the namespace:
+
+```bash
+oc create namespace nvidia-gpu-operator --context="$CTX" --dry-run=client -o yaml \
+  | oc apply --context="$CTX" -f -
+```
+
+Apply the OperatorGroup and Subscription. The GPU Operator uses **Manual**
+install plan approval so you control exactly which version lands on the
+cluster:
+
+```yaml
+apiVersion: operators.coreos.com/v1
+kind: OperatorGroup
+metadata:
+  name: nvidia-gpu-operator-group
+  namespace: nvidia-gpu-operator
+spec:
+  targetNamespaces:
+    - nvidia-gpu-operator
+---
+apiVersion: operators.coreos.com/v1alpha1
+kind: Subscription
+metadata:
+  name: gpu-operator-certified
+  namespace: nvidia-gpu-operator
+spec:
+  channel: v25.3
+  installPlanApproval: Manual
+  name: gpu-operator-certified
+  source: certified-operators
+  sourceNamespace: openshift-marketplace
+```
+
+```bash
+oc apply --context="$CTX" -f gpu-operator-subscription.yaml
+```
+
+Because `installPlanApproval` is `Manual`, you need to find and approve the
+InstallPlan:
+
+```bash
+# Wait for the InstallPlan to appear
+oc get installplan --context="$CTX" -n nvidia-gpu-operator -w
+```
+
+Once it appears with `APPROVED=false`, approve it:
+
+```bash
+INSTALL_PLAN=$(oc get installplan --context="$CTX" -n nvidia-gpu-operator \
+  -o jsonpath='{.items[?(@.spec.approved==false)].metadata.name}')
+
+oc patch installplan "$INSTALL_PLAN" --context="$CTX" -n nvidia-gpu-operator \
+  --type merge -p '{"spec": {"approved": true}}'
+```
+
+Wait for the CSV to succeed:
+
+```bash
+oc get csv --context="$CTX" -n nvidia-gpu-operator -w
+```
+
+## Step 3: Create a GPU MachineSet
+
+OpenShift manages worker nodes through MachineSets. Rather than writing one
+from scratch, clone an existing worker MachineSet and modify it for GPU use.
+
+The script below exports the first worker MachineSet, changes the instance
+type to `g6e.4xlarge` (1 NVIDIA L40S, 48 GB VRAM), increases the disk to
+200 GB, adds the `nvidia.com/gpu` taint, and sets replicas to 1:
+
+```bash
+# Clone an existing worker MachineSet for GPU
+WORKER_MS=$(oc get machineset --context="$CTX" -n openshift-machine-api \
+  -o jsonpath='{.items[0].metadata.name}')
+
+oc get machineset "$WORKER_MS" --context="$CTX" -n openshift-machine-api -o json | \
+  jq --arg name "gpu-${WORKER_MS}" '
+    .metadata.name = $name |
+    .metadata.resourceVersion = null |
+    .metadata.uid = null |
+    .metadata.creationTimestamp = null |
+    .spec.replicas = 1 |
+    .spec.selector.matchLabels["machine.openshift.io/cluster-api-machineset"] = $name |
+    .spec.template.metadata.labels["machine.openshift.io/cluster-api-machineset"] = $name |
+    .spec.template.spec.providerSpec.value.instanceType = "g6e.4xlarge" |
+    .spec.template.spec.providerSpec.value.blockDevices[0].ebs.volumeSize = 200 |
+    .spec.template.spec.taints = [{"key": "nvidia.com/gpu", "value": "", "effect": "NoSchedule"}]
+  ' | oc apply --context="$CTX" -f -
+```
+
+!!! warning "Node provisioning takes ~15 minutes"
+    AWS needs time to launch the instance, and the GPU Operator needs time to
+    install drivers on the new node. Watch progress:
+
+    ```bash
+    oc get machines --context="$CTX" -n openshift-machine-api -w
+    ```
+
+    The Machine will progress through `Provisioning` → `Provisioned` →
+    `Running`. Once it's `Running`, wait for the corresponding Node to become
+    `Ready`:
+
+    ```bash
+    oc get nodes --context="$CTX" -w
+    ```
+
+!!! tip "Instance type alternatives"
+    `g6e.4xlarge` provides an L40S with 48 GB VRAM at ~$1.60/hr. If your
+    region doesn't have `g6e` availability, `g5.4xlarge` (A10G, 24 GB VRAM,
+    ~$1.20/hr) also works for tutorial-sized models. Adjust `instanceType` in
+    the `jq` command above.
+
+## Step 4: Apply the ClusterPolicy
+
+The NVIDIA ClusterPolicy tells the GPU Operator how to configure drivers,
+device plugins, and monitoring on GPU nodes. Apply it after the operator is
+installed:
+
+```yaml
+apiVersion: nvidia.com/v1
+kind: ClusterPolicy
+metadata:
+  name: gpu-cluster-policy
+spec:
+  operator:
+    defaultRuntime: crio
+    use_ocp_driver_toolkit: true
+  driver:
+    enabled: true
+    upgradePolicy:
+      autoUpgrade: true
+      maxParallelUpgrades: 1
+      maxUnavailable: 25%
+  devicePlugin:
+    enabled: true
+  dcgm:
+    enabled: true
+  dcgmExporter:
+    enabled: true
+    serviceMonitor:
+      enabled: true
+  gfd:
+    enabled: true
+  migManager:
+    enabled: true
+    config:
+      default: all-disabled
+  nodeStatusExporter:
+    enabled: true
+  toolkit:
+    enabled: true
+  validator:
+    plugin:
+      env:
+        - name: WITH_WORKLOAD
+          value: "false"
+  daemonsets:
+    tolerations:
+      - key: nvidia.com/gpu
+        operator: Exists
+        effect: NoSchedule
+    updateStrategy: RollingUpdate
+    rollingUpdate:
+      maxUnavailable: "1"
+```
+
+!!! info "Key settings"
+    - `use_ocp_driver_toolkit: true` — uses the OpenShift Driver Toolkit to
+      build driver containers matched to your cluster's kernel version.
+    - `serviceMonitor: enabled: true` — exposes GPU metrics (utilization,
+      temperature, memory) to OpenShift's built-in Prometheus stack.
+    - The `daemonsets.tolerations` block ensures GPU Operator pods can
+      schedule onto nodes with the `nvidia.com/gpu` taint from Step 3.
+
+```bash
+oc apply --context="$CTX" -f cluster-policy.yaml
+```
+
+Wait for the ClusterPolicy to reach `ready` state. This can take several
+minutes as the operator builds and loads driver containers:
+
+```bash
+oc get clusterpolicy gpu-cluster-policy --context="$CTX" \
+  -o jsonpath='{.status.state}{"\n"}' -w
+```
+
+## Step 5: Verify GPU availability
+
+Once the ClusterPolicy is ready and the node is `Ready`, confirm that the
+GPU is visible to Kubernetes:
+
+```bash
+oc get nodes --context="$CTX" \
+  -o custom-columns=NAME:.metadata.name,GPU:.status.capacity."nvidia\.com/gpu"
+```
+
+You should see one node reporting a GPU capacity of `1`. If the GPU column
+shows `<none>` for all nodes, the driver pods may still be initializing.
+Check their status:
+
+```bash
+oc get pods --context="$CTX" -n nvidia-gpu-operator
+```
+
+All pods should be `Running` or `Completed`. If any are stuck in
+`CrashLoopBackOff`, check their logs for driver compatibility issues.
+
+## (Optional) Create a Hardware Profile
+
+If you use the RHOAI dashboard to deploy models, a HardwareProfile makes
+GPU resources selectable in the UI. This step is optional if you only deploy
+models via CLI manifests.
+
+```yaml
+apiVersion: infrastructure.opendatahub.io/v1
+kind: HardwareProfile
+metadata:
+  name: nvidia-gpu
+  namespace: redhat-ods-applications
+  labels:
+    app.kubernetes.io/part-of: hardwareprofile
+    app.opendatahub.io/hardwareprofile: "true"
+  annotations:
+    opendatahub.io/display-name: "NVIDIA GPU"
+    opendatahub.io/description: "NVIDIA GPU accelerator for AI/ML workloads"
+    opendatahub.io/disabled: "false"
+spec:
+  identifiers:
+    - displayName: CPU
+      identifier: cpu
+      defaultCount: 2
+      maxCount: 8
+      minCount: 1
+      resourceType: CPU
+    - displayName: Memory
+      identifier: memory
+      defaultCount: 8Gi
+      maxCount: 32Gi
+      minCount: 2Gi
+      resourceType: Memory
+    - displayName: GPU
+      identifier: nvidia.com/gpu
+      defaultCount: 1
+      maxCount: 1
+      minCount: 1
+      resourceType: Accelerator
+  scheduling:
+    type: Node
+    node:
+      tolerations:
+        - key: nvidia.com/gpu
+          operator: Exists
+          effect: NoSchedule
+```
+
+```bash
+oc apply --context="$CTX" -f hardware-profile.yaml
+```
+
+The profile will appear under **Settings > Hardware profiles** in the RHOAI
+dashboard.
+
+## Next
+
+[Install OpenShift AI](install-openshift-ai.md).

--- a/docs/guides/install-cli-tools.md
+++ b/docs/guides/install-cli-tools.md
@@ -99,9 +99,9 @@ fips-agents --version
 ```
 
 !!! note "CLI version"
-    This tutorial was tested with fips-agents v0.15.1. Newer versions are
+    This tutorial was tested with fips-agents v0.15.3. Newer versions are
     backward-compatible but may produce slightly different scaffold output.
-    To install the exact version: `pipx install 'fips-agents-cli==0.15.1'`
+    To install the exact version: `pipx install 'fips-agents-cli==0.15.3'`
 
 ## Log in to your cluster
 

--- a/docs/guides/install-openshift-ai.md
+++ b/docs/guides/install-openshift-ai.md
@@ -49,9 +49,13 @@ From the OpenShift web console:
     export CTX=$(oc config current-context)
     ```
 
-Or from the CLI:
+Or from the CLI — create the namespace first, then apply the OperatorGroup
+and Subscription:
 
 ```bash
+oc create namespace redhat-ods-operator --context="$CTX" \
+  --dry-run=client -o yaml | oc apply --context="$CTX" -f -
+
 oc apply --context="$CTX" -n redhat-ods-operator -f - <<EOF
 apiVersion: operators.coreos.com/v1
 kind: OperatorGroup

--- a/docs/guides/serve-an-llm.md
+++ b/docs/guides/serve-an-llm.md
@@ -131,6 +131,8 @@ spec:
           value: /tmp/home
         - name: HF_HOME
           value: /models/huggingface
+        - name: HF_HUB_OFFLINE
+          value: "0"
         - name: TRANSFORMERS_CACHE
           value: /models/huggingface
         - name: VLLM_CACHE_DIR

--- a/docs/reference/makefile.md
+++ b/docs/reference/makefile.md
@@ -126,6 +126,20 @@ make redeploy PROJECT=calculus-demo
 make clean PROJECT=calculus-demo
 ```
 
+!!! tip "Single-command alternative"
+    The `fips-agents deploy` command handles deployment for both agents and MCP
+    servers in one step. It auto-detects the project type and applies the
+    appropriate deployment method:
+    
+    ```bash
+    # Works for both agent and MCP server projects
+    fips-agents deploy --context="$CTX" -n calculus-demo
+    ```
+    
+    This is the **recommended approach** for day-to-day development. The Makefile
+    targets are still useful for scripting, CI/CD pipelines, or when you need
+    fine-grained control over the deployment process.
+
 === "Agent"
 
     `deploy` calls `deploy.sh`, which applies the Helm chart from `chart/`.

--- a/docs/supplementary/agent-memory.md
+++ b/docs/supplementary/agent-memory.md
@@ -52,11 +52,13 @@ Verify the MCP endpoint is reachable:
 ```bash
 curl -sf https://memory-hub-mcp-memory-hub-mcp.apps.<cluster>/mcp/ \
   -H "Content-Type: application/json" \
+  -H "Accept: application/json, text/event-stream" \
   -d '{"jsonrpc":"2.0","method":"tools/list","id":1}' | python -m json.tool
 ```
 
 Replace `<cluster>` with your cluster's apps domain. A successful response
-lists MemoryHub's MCP tools (`memory_search`, `memory_write`, `memory_list`,
+lists MemoryHub's MCP tools: `register_session` and `memory` (a unified tool
+whose `action` parameter selects the operation -- `search`, `write`, `list`,
 etc.).
 
 !!! tip "Local development without a cluster deployment"
@@ -115,6 +117,7 @@ results = await self.memory.search("calculus preferences", max_results=5)
 
 await self.memory.write(
     content="User prefers step-by-step solutions",
+    content_type="behavioral",
     scope="user",
     weight=0.8,
 )
@@ -130,6 +133,11 @@ model:
 | `role` | All agents with a given role | "Calculus tutors show worked steps" |
 | `organizational` | All agents in an org | "Company style guide rules" |
 | `enterprise` | All agents everywhere | "Compliance: no PII in responses" |
+
+The `content_type` parameter classifies what the memory represents:
+`experiential` (events and interactions), `knowledge` (facts and information),
+or `behavioral` (preferences and patterns). MemoryHub uses this for curation
+and retrieval ranking.
 
 The `weight` parameter (0.0--1.0) signals how important the memory is.
 Higher-weight memories rank higher in search results and are less likely to be
@@ -174,47 +182,50 @@ the memory was persisted:
 ```bash
 curl -s https://memory-hub-mcp-memory-hub-mcp.apps.<cluster>/mcp/ \
   -H "Content-Type: application/json" \
+  -H "Accept: application/json, text/event-stream" \
   -d '{
     "jsonrpc": "2.0",
     "method": "tools/call",
-    "params": {"name": "memory_search", "arguments": {"query": "preferences", "max_results": 5}},
+    "params": {"name": "memory", "arguments": {"action": "search", "query": "preferences", "max_results": 5}},
     "id": 1
   }' | python -m json.tool
 ```
 
-### Curation rejection
+### Curation and duplicate detection
 
 MemoryHub doesn't accept every write blindly. A curation layer checks each
 incoming memory against existing content and configured rules before
-persisting it. If the write is too similar to an existing memory, or violates
-a curation rule, MemoryHub blocks it and returns a structured rejection.
+persisting it. If the write is too similar to an existing memory, MemoryHub
+flags it with a similarity warning and a recommendation.
 
 Try it: write the same fact twice. The first write succeeds. The second
-triggers a near-duplicate rejection:
+gets flagged as a possible duplicate:
 
 ```python
 # First write -- succeeds
 await self.memory.write(
     content="User prefers step-by-step solutions",
+    content_type="behavioral",
     scope="user",
     weight=0.8,
 )
 
-# Second write -- blocked by curation
+# Second write -- flagged as possible duplicate
 result = await self.memory.write(
     content="The user prefers step-by-step solutions",
+    content_type="behavioral",
     scope="user",
     weight=0.8,
 )
 ```
 
-The rejection response includes the reason, the similar memory's ID and
-similarity score, and a recommendation:
+The response includes a similarity flag, the near-duplicate's ID and score,
+and a recommendation:
 
 ```json
 {
-  "blocked": true,
-  "reason": "exact_duplicate",
+  "blocked": false,
+  "reason": "possible_duplicate",
   "detail": "Memory is 99% similar to existing memory b7ba6e8e-...",
   "nearest_score": 0.9869,
   "existing_memory_id": "b7ba6e8e-...",
@@ -222,10 +233,14 @@ similarity score, and a recommendation:
 }
 ```
 
-The `recommendation` field tells the agent what to do instead -- in this case,
-update the existing memory rather than creating a duplicate. The fips-agents
-`MemoryClient` surfaces this as a structured return value; in kagenti ADK (Part
-2), the equivalent is a `MemoryRejectionError` exception.
+Note that `"blocked"` is `false` -- by default, MemoryHub flags near-duplicates
+rather than rejecting them outright. The write still succeeds, but the
+`recommendation` field tells the agent it should update the existing memory
+instead of creating duplicates. Whether near-duplicates are hard-blocked
+depends on the MemoryHub instance's similarity threshold configuration.
+
+The fips-agents `MemoryClient` surfaces this as a structured return value; in
+kagenti ADK (Part 2), the equivalent is a `MemoryRejectionError` exception.
 
 This is the curation system working as designed. Without it, agents that
 write aggressively (common with LLM-driven memory) would fill the store with
@@ -383,7 +398,7 @@ model. The differences are in wiring and credential flow:
 | Credential management | Agent-side (env vars or Secret) | Client-side (fulfillment metadata) |
 | Backend | MemoryHub MCP | MemoryHub MCP |
 | Scoping model | Same 5-tier scoping | Same 5-tier scoping |
-| Curation rejection | Handled by `MemoryClient` | `MemoryRejectionError` exception |
+| Curation flagging | Handled by `MemoryClient` | `MemoryRejectionError` exception |
 
 The fips-agents path is simpler to set up and fits naturally into the
 `agent.yaml` configuration model you've been using throughout the tutorial. The

--- a/docs/supplementary/maas-model-serving.md
+++ b/docs/supplementary/maas-model-serving.md
@@ -128,7 +128,7 @@ metadata:
   namespace: openshift-operators
 spec:
   channel: stable
-  name: connectivity-link-operator
+  name: rhcl-operator
   source: redhat-operators
   sourceNamespace: openshift-marketplace
 EOF
@@ -182,11 +182,7 @@ cluster standards require, then create the connection secret in the
 ```bash
 oc create secret generic maas-db-config \
   -n redhat-ods-applications \
-  --from-literal=host=<postgres-host> \
-  --from-literal=port=5432 \
-  --from-literal=dbname=maas \
-  --from-literal=user=maas \
-  --from-literal=password=<password>
+  --from-literal=DB_CONNECTION_URL="postgresql://<user>:<password>@<postgres-host>:5432/<dbname>"
 ```
 
 !!! tip "Database timing"
@@ -317,7 +313,7 @@ oc patch authorino authorino -n kuadrant-system --type merge -p '{
 **7c.** Add CA bundle environment variables to the Authorino deployment:
 
 ```bash
-oc set env deployment/authorino-authorino-authorization \
+oc set env deployment/authorino \
   SSL_CERT_FILE=/etc/ssl/certs/openshift-service-ca/service-ca-bundle.crt \
   REQUESTS_CA_BUNDLE=/etc/ssl/certs/openshift-service-ca/service-ca-bundle.crt \
   -n kuadrant-system

--- a/docs/supplementary/maas-model-serving.md
+++ b/docs/supplementary/maas-model-serving.md
@@ -45,32 +45,348 @@ MaaS requires several platform components: Red Hat Connectivity Link
 (Kuadrant, Authorino, Limitador), a PostgreSQL database for API key
 management, an API gateway with TLS, and dashboard configuration.
 
-Follow the official Red Hat guide to deploy MaaS:
-
-**[Deploy and manage Models-as-a-Service](https://docs.redhat.com/en/documentation/red_hat_openshift_ai_self-managed/3.4/html/govern_llm_access_with_models-as-a-service/deploy-and-manage-models-as-a-service_maas#maas-prerequisites_maas-deploy)**
+The authoritative reference is the
+[official Red Hat guide](https://docs.redhat.com/en/documentation/red_hat_openshift_ai_self-managed/3.4/html/govern_llm_access_with_models-as-a-service/deploy-and-manage-models-as-a-service_maas).
+The steps below inline the key operations with troubleshooting context that
+the official guide does not cover.
 
 !!! note "Red Hat account required"
     The official guide requires a Red Hat login. If you don't have one,
     create a free account at [access.redhat.com](https://access.redhat.com).
 
-Work through the prerequisites section and the initial configuration steps.
-When you are done, verify the deployment:
+### Step 1: Install the Limitador operator
+
+Subscribe from OperatorHub on the `stable` channel from the
+`redhat-operators` catalog. The operator installs into `openshift-operators`.
+
+```bash
+oc apply -f - <<EOF
+apiVersion: operators.coreos.com/v1alpha1
+kind: Subscription
+metadata:
+  name: limitador-operator
+  namespace: openshift-operators
+spec:
+  channel: stable
+  name: limitador-operator
+  source: redhat-operators
+  sourceNamespace: openshift-marketplace
+EOF
+```
+
+Wait for the CSV to succeed:
+
+```bash
+oc get csv -n openshift-operators -l operators.coreos.com/limitador-operator.openshift-operators
+```
+
+### Step 2: Install or upgrade the Authorino operator
+
+!!! warning "Upgrading from RHOAI 3.3"
+    If you have Authorino v1.1.3 on the `tech-preview-v1` channel, it is
+    too old for Connectivity Link. Delete the old Subscription and CSV
+    first, then install fresh on `stable`. This can briefly disrupt cluster
+    auth.
+
+    ```bash
+    oc delete subscription authorino-operator -n openshift-operators
+    oc delete csv -l operators.coreos.com/authorino-operator.openshift-operators \
+      -n openshift-operators
+    ```
+
+For a fresh install, subscribe on the `stable` channel (v1.3.0+):
+
+```bash
+oc apply -f - <<EOF
+apiVersion: operators.coreos.com/v1alpha1
+kind: Subscription
+metadata:
+  name: authorino-operator
+  namespace: openshift-operators
+spec:
+  channel: stable
+  name: authorino-operator
+  source: redhat-operators
+  sourceNamespace: openshift-marketplace
+EOF
+```
+
+The operator installs into `openshift-operators`, but the Authorino CR will
+live in `kuadrant-system` (managed by RHCL in Step 4).
+
+### Step 3: Install the Red Hat Connectivity Link (RHCL) operator
+
+Subscribe on the `stable` channel (v1.3.3). This brings Kuadrant
+capabilities to the cluster.
+
+```bash
+oc apply -f - <<EOF
+apiVersion: operators.coreos.com/v1alpha1
+kind: Subscription
+metadata:
+  name: connectivity-link-operator
+  namespace: openshift-operators
+spec:
+  channel: stable
+  name: connectivity-link-operator
+  source: redhat-operators
+  sourceNamespace: openshift-marketplace
+EOF
+```
+
+### Step 4: Create the Kuadrant CR
+
+Installing the RHCL operator is not enough -- you must also create the
+Kuadrant custom resource:
+
+```bash
+oc create namespace kuadrant-system --dry-run=client -o yaml | oc apply -f -
+
+oc apply -f - <<EOF
+apiVersion: kuadrant.io/v1beta1
+kind: Kuadrant
+metadata:
+  name: kuadrant
+  namespace: kuadrant-system
+spec: {}
+EOF
+```
+
+Wait for Ready:
+
+```bash
+oc get kuadrant kuadrant -n kuadrant-system \
+  -o jsonpath='{.status.conditions[?(@.type=="Ready")].status}'
+# Should print True
+```
+
+!!! warning "Kuadrant stuck in MissingDependency"
+    Kuadrant checks for Limitador during initialization and caches a
+    `MissingDependency` status permanently if Limitador was not ready in
+    time. If the Kuadrant CR stays in `MissingDependency` after Limitador
+    is healthy, restart the Kuadrant operator pod:
+
+    ```bash
+    oc delete pod -l app.kubernetes.io/name=kuadrant-operator \
+      -n kuadrant-system
+    ```
+
+    Then re-check readiness.
+
+### Step 5: Deploy PostgreSQL and create the database secret
+
+MaaS needs PostgreSQL for API key management. Deploy PostgreSQL however your
+cluster standards require, then create the connection secret in the
+`redhat-ods-applications` namespace:
+
+```bash
+oc create secret generic maas-db-config \
+  -n redhat-ods-applications \
+  --from-literal=host=<postgres-host> \
+  --from-literal=port=5432 \
+  --from-literal=dbname=maas \
+  --from-literal=user=maas \
+  --from-literal=password=<password>
+```
+
+!!! tip "Database timing"
+    If the `maas-api` pod starts before the database is ready, the schema
+    will not initialize. Restart it after the database is available:
+
+    ```bash
+    oc rollout restart deployment/maas-api -n redhat-ods-applications
+    ```
+
+### Step 6: Create the MaaS gateway
+
+Create a Gateway in the `openshift-ingress` namespace with ClusterIP service
+type and passthrough Routes for external access.
+
+```yaml
+# maas-gateway.yaml
+apiVersion: gateway.networking.k8s.io/v1
+kind: Gateway
+metadata:
+  name: maas-default-gateway
+  namespace: openshift-ingress
+  annotations:
+    opendatahub.io/managed: "false"
+    security.opendatahub.io/authorino-tls-bootstrap: "true"
+spec:
+  gatewayClassName: data-science-gateway-class  # (1)
+  listeners:
+    - name: https
+      port: 443
+      protocol: HTTPS
+      tls:
+        mode: Terminate
+        certificateRefs:
+          - name: maas-default-gateway-cert
+      allowedRoutes:
+        namespaces:
+          from: All
+```
+
+1. Find your GatewayClass: `oc get gatewayclasses`
+
+Then create two passthrough Routes for external access:
+
+```yaml
+# maas-routes.yaml
+apiVersion: route.openshift.io/v1
+kind: Route
+metadata:
+  name: maas-gateway
+  namespace: openshift-ingress
+spec:
+  host: maas.apps.<cluster-domain>
+  to:
+    kind: Service
+    name: maas-default-gateway-data-science-gateway-class
+  port:
+    targetPort: https
+  tls:
+    termination: passthrough
+---
+apiVersion: route.openshift.io/v1
+kind: Route
+metadata:
+  name: maas-inference-gateway
+  namespace: openshift-ingress
+spec:
+  host: inference.maas.apps.<cluster-domain>
+  to:
+    kind: Service
+    name: maas-default-gateway-data-science-gateway-class
+  port:
+    targetPort: https
+  tls:
+    termination: passthrough
+```
+
+```bash
+oc apply -f maas-gateway.yaml
+oc apply -f maas-routes.yaml
+```
+
+!!! warning "Do not put hostnames on Gateway listeners"
+    The gateway service uses ClusterIP with passthrough Routes for external
+    access. Placing hostnames directly on listeners can cause DNS record
+    hijacking -- the gateway takes over records from OpenShift's default
+    router.
+
+    Also note: `*.maas.apps.<domain>` (wildcard) matches subdomains like
+    `inference.maas.apps.<domain>` but NOT the bare `maas.apps.<domain>`.
+    If you need both, create explicit Routes for each.
+
+### Step 7: Configure TLS for Authorino
+
+Three steps are required -- setting `certSecretRef` alone is not enough.
+
+**7a.** Annotate the Authorino service for a serving certificate:
+
+```bash
+oc annotate service authorino-authorino-authorization \
+  service.beta.openshift.io/serving-cert-secret-name=authorino-server-cert \
+  -n kuadrant-system
+```
+
+**7b.** Patch the Authorino CR with TLS enabled:
+
+```bash
+oc patch authorino authorino -n kuadrant-system --type merge -p '{
+  "spec": {
+    "listener": {
+      "tls": {
+        "enabled": true,
+        "certSecretRef": {
+          "name": "authorino-server-cert"
+        }
+      }
+    }
+  }
+}'
+```
+
+!!! warning "`enabled: true` is required"
+    Setting only `certSecretRef` looks correct but fails silently --
+    gateway-to-Authorino communication breaks and models will not appear
+    in Gen AI Studio. You must set `enabled: true` alongside
+    `certSecretRef`.
+
+**7c.** Add CA bundle environment variables to the Authorino deployment:
+
+```bash
+oc set env deployment/authorino-authorino-authorization \
+  SSL_CERT_FILE=/etc/ssl/certs/openshift-service-ca/service-ca-bundle.crt \
+  REQUESTS_CA_BUNDLE=/etc/ssl/certs/openshift-service-ca/service-ca-bundle.crt \
+  -n kuadrant-system
+```
+
+### Step 8: Enable User Workload Monitoring
+
+```bash
+oc apply -f - <<EOF
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: cluster-monitoring-config
+  namespace: openshift-monitoring
+data:
+  config.yaml: |
+    enableUserWorkload: true
+EOF
+```
+
+Without User Workload Monitoring, MaaS reports a Degraded status.
+
+### Step 9: Enable MaaS in the DataScienceCluster
+
+```bash
+oc patch dsc default-dsc --type merge -p '{
+  "spec": {
+    "components": {
+      "kserve": {
+        "modelsAsService": {
+          "managementState": "Managed"
+        }
+      }
+    }
+  }
+}'
+```
+
+### Step 10: Enable dashboard feature flags
+
+```bash
+oc patch odhdashboardconfig odh-dashboard-config \
+  -n redhat-ods-applications --type merge -p '{
+  "spec": {
+    "dashboardConfig": {
+      "modelAsService": true,
+      "genAiStudio": true,
+      "maasAuthPolicies": true
+    }
+  }
+}'
+```
+
+### Step 11: Verify the deployment
 
 ```bash
 oc get tenants.maas.opendatahub.io default-tenant \
   -n models-as-a-service
-# READY should be True
 ```
 
-!!! warning "Gotchas we found during testing"
-    These issues are not covered in the official guide but came up during
-    our validation on fresh clusters:
+READY should be True. If it is not, work backwards through Kuadrant CR
+status, Authorino TLS configuration, and User Workload Monitoring.
 
+!!! warning "Additional troubleshooting"
     **AI Hub model catalog requires Model Registry.** To see the model
-    catalog under AI Hub in the dashboard, enable `modelregistry` in the
-    DSC and `llamastackoperator` for GenAI Studio:
+    catalog under AI Hub in the dashboard, enable `modelregistry` and
+    `llamastackoperator` in the DSC:
 
-    ```
+    ```bash
     oc patch dsc default-dsc --type merge -p '{
       "spec": {
         "components": {
@@ -85,25 +401,15 @@ oc get tenants.maas.opendatahub.io default-tenant \
     ```
 
     **Gateway must allow cross-namespace routes.** The MaaS controller
-    creates HTTPRoutes in model namespaces. Add
-    `allowedRoutes.namespaces.from: All` to the gateway listener, or model
-    deployments fail with `NotAllowedByListeners`.
+    creates HTTPRoutes in model namespaces. The
+    `allowedRoutes.namespaces.from: All` in the gateway listener handles
+    this -- if you see `NotAllowedByListeners`, check your gateway config.
 
-    **Restart maas-api after creating the database.** If PostgreSQL is
-    deployed after the `maas-api` pod starts, the database schema won't
-    be initialized. Run
-    `oc rollout restart deployment/maas-api -n redhat-ods-applications`
-    to trigger the migration.
-
-    **GPU node taints.** If your GPU nodes have a `nvidia.com/gpu:NoSchedule`
-    taint, the `LLMInferenceService` controller does not propagate
-    tolerations from hardware profiles. Either remove the taint from GPU
-    nodes or patch the Deployment directly after model deployment.
-
-    **Authorino upgrade from RHOAI 3.3.** If upgrading from 3.3, the
-    Authorino operator (v1.1.3, `tech-preview-v1` channel) is too old for
-    Connectivity Link. Delete the old Subscription and CSV, then recreate
-    on the `stable` channel. This can briefly disrupt cluster auth.
+    **GPU node taints.** If your GPU nodes have a
+    `nvidia.com/gpu:NoSchedule` taint, the `LLMInferenceService`
+    controller does not propagate tolerations from hardware profiles.
+    Either remove the taint from GPU nodes or patch the Deployment
+    directly after model deployment.
 
 ## Part 2: Deploy a model from the AI Hub catalog
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -55,6 +55,7 @@ nav:
     - "MCP Gateway": supplementary/mcp-gateway.md
   - Setup Guides:
     - "Choosing a Cluster": guides/cluster-options.md
+    - "GPU Node Setup": guides/gpu-node-setup.md
     - "Install OpenShift AI": guides/install-openshift-ai.md
     - "Serve an LLM": guides/serve-an-llm.md
     - "Install CLI Tools": guides/install-cli-tools.md


### PR DESCRIPTION
## Summary

- Inline the verified 11-step MaaS setup sequence with troubleshooting callouts for 5 hard-won lessons (Kuadrant race condition, Authorino TLS, gateway DNS hijacking, wildcard DNS, User Workload Monitoring)
- Add GPU Node Setup guide — fills a critical gap where students had no instructions for provisioning GPU nodes on AWS
- Fix 18 documentation bugs found during two full end-to-end walkthroughs on fresh OCP 4.20.23 clusters
- Switch MCP server deployment to `fips-agents deploy`; agent deployment uses manual BuildConfig + Helm (CLI agent support tracked in fips-agents/fips-agents-cli#56)

## Test plan

- [x] Full course walkthrough (Modules 0-9) on fa-example cluster (OCP 4.20.23, RHOAI 3.3.1/3.4.0)
- [x] Full course walkthrough (Modules 0-9) on course-test cluster (OCP 4.20.23, RHOAI 3.3.1/3.4.0)
- [x] MaaS supplementary module (all 11 steps) on both clusters
- [x] MemoryHub supplementary module on fa-example
- [x] Modules 10-11 documentation review (conceptual modules, no hands-on)
- [x] `mkdocs build --strict` passes on all commits
- [x] `fips-agents deploy --dry-run` verified for both agent and MCP server projects

## Upstream issues filed

- fips-agents/fips-agents-cli#55 — `fips-agents deploy` end-to-end gaps (closed, fixed in v0.15.2)
- fips-agents/fips-agents-cli#56 — agent build pipeline + nil config map (open)
- fips-agents/mcp-server-template#10 — deploy.sh context safety (closed)
- fips-agents/agent-template#223 — Makefile context flags (closed)
- redhat-ai-americas/memory-hub#252 — tool API + Accept header (closed)